### PR TITLE
refactor: replace dialect subclasses with dialect parameter on Query and Table

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@
 [![license](https://img.shields.io/github/license/mashape/apistatus.svg?maxAge=2592000)](https://github.com/danielenricocahall/pysqlscribe/blob/master/LICENSE)
 
 
-At some point during a project, whether it be personal or professional, you have likely needed to use SQL to interact with a relational database in your application code. In the event they are tables your team owns, you may have used an object-relational mapper (ORM) - such as [SQLAlchemy](https://www.sqlalchemy.org/), [Django](https://docs.djangoproject.com/en/5.2/topics/db/queries/#), [Advanced Alchemy](https://github.com/litestar-org/advanced-alchemy), or [Piccolo](https://github.com/piccolo-orm/piccolo). However, if the operations are primarily read-only (for example, reading and presenting information on tables which are externally updated by another process) integrating an ORM either isn’t feasible or would induce more extra complexity than it’s worth. In this case, options are fairly limited outside of writing raw SQL queries in code, which introduces a different type of complexity around sanitizing and validating inputs, ensuring proper syntax, and all the other stuff (likely) engineers don’t want to expend energy on.
+At some point during a project, whether it be personal or professional, you have likely needed to use SQL to interact with a relational database in your application code. In the event they are tables your team owns, you may have used an object-relational mapper (ORM) - such as [SQLAlchemy](https://www.sqlalchemy.org/), [Django](https://docs.djangoproject.com/en/5.2/topics/db/queries/#), [Advanced Alchemy](https://github.com/litestar-org/advanced-alchemy), or [Piccolo](https://github.com/piccolo-orm/piccolo). However, if the operations are primarily read-only (for example, reading and presenting information on tables which are externally updated by another process) integrating an ORM either isn't feasible or would induce more extra complexity than it's worth. In this case, options are fairly limited outside of writing raw SQL queries in code, which introduces a different type of complexity around sanitizing and validating inputs, ensuring proper syntax, and all the other stuff (likely) engineers don't want to expend energy on.
 
 
 While LLMs are fairly adept at building queries given the quantity of SQL on the internet, it still requires providing the table structure as context via DDL, verbal description, or an external tool that enables table metadata discovery. Additionally, when making updates, coding agents will need to ingest the strings and may make changes, potentially untested.
 
-This is `pysqlscribe`, a query building library which enables building SQL queries using objects. 
+This is `pysqlscribe`, a query building library which enables building SQL queries using objects.
 
 # Highlights
-- **Dialect Support**: Currently supports `mysql`, `postgres`, and `oracle`. More dialects can be added by subclassing the `Query` class and registering it with the `QueryRegistry`.
-- Dependency Free: No external dependencies outside of the Python standard library.
+- **Dialect Support**: Currently supports `mysql`, `postgres`, `oracle`, and `sqlite`. The dialect is supplied as a string argument — no subclassing required.
+- **Dependency Free**: No external dependencies outside of the Python standard library.
 - **Multiple APIs**: Offers multiple APIs for building queries, including a `Query` class, a `Table` class, and a `Schema` class.
 - **DDL Parser/Loader**: Can parse DDL files to create `Table` objects, facilitating integration with existing database schema definitions.
 - **Safe by default**: All identifiers are escaped by default to prevent SQL injection attacks, with the option to disable this behavior if desired.
@@ -31,47 +31,28 @@ pip install pysqlscribe
 
 ## Query
 
-A `Query` object can be constructed using the `QueryRegistry`'s `get_builder` if you supply a valid dialect (e.g; "mysql", "postgres", "oracle"). For example, "mysql" would be:
+A `Query` object is constructed by passing a dialect string (e.g. `"mysql"`, `"postgres"`, `"oracle"`, `"sqlite"`):
 
 ```python
-from pysqlscribe.query import QueryRegistry
+from pysqlscribe.query import Query
 
-query_builder = QueryRegistry.get_builder("mysql")
+query_builder = Query("mysql")
 query = query_builder.select("test_column", "another_test_column").from_("test_table").build()
 ```
 
-Alternatively, you can create the corresponding `Query` class associated with the dialect directly:
-
-```python
-from pysqlscribe.query import MySQLQuery
-
-query_builder = MySQLQuery()
-query = query_builder.select("test_column", "another_test_column").from_("test_table").build()
-```
-In both cases, the output is:
+Output:
 
 ```mysql
 SELECT `test_column`,`another_test_column` FROM `test_table`
 ```
 
-Furthermore, if there are any dialects that we currently don't support, you can create your own by subclassing `Query` and registering it with the `QueryRegistry`:
-
-```python
-from pysqlscribe.query import QueryRegistry, Query
-
-
-@QueryRegistry.register("custom")
-class CustomQuery(Query):
-    ...
-```
-
 ## Table
-An alternative method for building queries is through the `Table` object:
+An alternative method for building queries is through the `Table` object. The `dialect` is supplied as a keyword argument:
 
 ```python
-from pysqlscribe.table import MySQLTable
+from pysqlscribe.table import Table
 
-table = MySQLTable("test_table", "test_column", "another_test_column")
+table = Table("test_table", "test_column", "another_test_column", dialect="mysql")
 query = table.select("test_column").build()
 ```
 
@@ -80,12 +61,12 @@ Output:
 SELECT `test_column` FROM `test_table`
 ```
 
-A schema for the table can also be provided as a keyword argument, after the columns:
+A schema for the table can also be provided:
 
 ```python
-from pysqlscribe.table import MySQLTable
+from pysqlscribe.table import Table
 
-table = MySQLTable("test_table", "test_column", "another_test_column", schema="test_schema")
+table = Table("test_table", "test_column", "another_test_column", dialect="mysql", schema="test_schema")
 query = table.select("test_column").build()
 ```
 
@@ -94,34 +75,24 @@ Output:
 SELECT `test_column` FROM `test_schema.test_table`
 ```
 
-`Table` also offers a `create` method in the event you've added a new dialect which doesn't have an associated `Table` implementation, or if you need to change it for different environments (e.g; `sqlite` for local development, `mysql`/`postgres`/`oracle`/etc. for deployment):
+You can overwrite the original columns supplied to a `Table` as well, which will delete the old attributes and set new ones:
 
 ```python
 from pysqlscribe.table import Table
 
-new_dialect_table_class = Table.create(
-    "new-dialect")  # assuming you've registered "new-dialect" with the `QueryRegistry`
-table = new_dialect_table_class("test_table", "test_column", "another_test_column")
-```
-
-You can overwrite the original columns supplied to a `Table` as well, which will delete the old attributes and set new ones:
-
-```python
-from pysqlscribe.table import MySQLTable
-
-table = MySQLTable("test_table", "test_column", "another_test_column")
+table = Table("test_table", "test_column", "another_test_column", dialect="mysql")
 table.test_column  # valid
-table.fields = ['new_test_column']
+table.columns = ['new_test_column']
 table.select("new_test_column")
 table.new_test_column  # now valid - but `table.test_column` is not anymore
 ```
 
-Additionally, you can reference the `Column` attributes `Table` object when constructing queries. For example, in a `WHERE` clause:
+Additionally, you can reference the `Column` attributes on a `Table` object when constructing queries. For example, in a `WHERE` clause:
 
 ```python
-from pysqlscribe.table import PostgresTable
+from pysqlscribe.table import Table
 
-table = PostgresTable("employee", "first_name", "last_name", "salary", "location")
+table = Table("employee", "first_name", "last_name", "salary", "location", dialect="postgres")
 table.select("first_name", "last_name", "location").where(table.salary > 1000).build()
 ```
 
@@ -134,12 +105,10 @@ SELECT "first_name","last_name","location" FROM "employee" WHERE salary > 1000
 and in a `JOIN`:
 
 ```python
-from pysqlscribe.table import PostgresTable
+from pysqlscribe.table import Table
 
-employee_table = PostgresTable(
-        "employee", "first_name", "last_name", "dept", "payroll_id"
-    )
-payroll_table = PostgresTable("payroll", "id", "salary", "category")
+employee_table = Table("employee", "first_name", "last_name", "dept", "payroll_id", dialect="postgres")
+payroll_table = Table("payroll", "id", "salary", "category", dialect="postgres")
 query = (
     employee_table.select(
         employee_table.first_name, employee_table.last_name, employee_table.dept
@@ -168,10 +137,10 @@ schema.tables  # a list of two `Table` objects
 This is functionally equivalent to:
 
 ```python
-from pysqlscribe.table import PostgresTable
+from pysqlscribe.table import Table
 
-table = PostgresTable("test_table", schema="test_schema")
-another_table = PostgresTable("another_test_table", schema="test_schema")
+table = Table("test_table", dialect="postgres", schema="test_schema")
+another_table = Table("another_test_table", dialect="postgres", schema="test_schema")
 ```
 
 Instead of supplying a `dialect` directly to `Schema`, you can also set the environment variable `PYSQLSCRIBE_BUILDER_DIALECT`:
@@ -184,17 +153,17 @@ export PYSQLSCRIBE_BUILDER_DIALECT = 'postgres'
 from pysqlscribe.schema import Schema
 
 schema = Schema("test_schema", tables=["test_table", "another_test_table"])
-schema.tables  # a list of two `PostgresTable` objects
+schema.tables  # a list of two `Table` objects
 ```
 
 Alternatively, if you already have existing `Table` objects you want to associate with the schema, you can supply them directly (in this case, `dialect` is not needed):
 
 ```python
 from pysqlscribe.schema import Schema
-from pysqlscribe.table import PostgresTable
+from pysqlscribe.table import Table
 
-table = PostgresTable("test_table")
-another_table = PostgresTable("another_test_table")
+table = Table("test_table", dialect="postgres")
+another_table = Table("another_test_table", dialect="postgres")
 schema = Schema("test_schema", [table, another_table])
 ```
 
@@ -209,9 +178,9 @@ schema.test_table # will return the supplied table object with the name `"test_t
 Arithmetic operations can be performed on columns, both on `Column` objects and scalar values:
 
 ```python
-from pysqlscribe.table import MySQLTable
+from pysqlscribe.table import Table
 
-table = MySQLTable("employees", "salary", "bonus", "lti")
+table = Table("employees", "salary", "bonus", "lti", dialect="mysql")
 query = table.select(
     (table.salary + table.bonus + table.lti).as_("total_compensation")
 ).build()
@@ -220,13 +189,13 @@ query = table.select(
 Output:
 
 ```mysql
-SELECT employees.salary + employees.bonus + employees.lti AS total_compensation FROM `employees` 
+SELECT employees.salary + employees.bonus + employees.lti AS total_compensation FROM `employees`
 ```
 
 ```python
-from pysqlscribe.table import MySQLTable
+from pysqlscribe.table import Table
 
-table = MySQLTable("employees", "salary", "bonus", "lti")
+table = Table("employees", "salary", "bonus", "lti", dialect="mysql")
 query = table.select((table.salary * 0.75).as_("salary_after_taxes")).build()
 ```
 
@@ -241,8 +210,9 @@ SELECT employees.salary * 0.75 AS salary_after_taxes FROM `employees`
 Membership operations such as `IN` and `NOT IN` are supported:
 
 ```python
-from pysqlscribe.table import MySQLTable
-table = MySQLTable("employees", "salary", "bonus", "department_id")
+from pysqlscribe.table import Table
+
+table = Table("employees", "salary", "bonus", "department_id", dialect="mysql")
 query = table.select().where(table.department_id.in_([1, 2, 3])).build()
 
 ```
@@ -258,12 +228,11 @@ SELECT * FROM `employees` WHERE department_id IN (1,2,3)
 For computing aggregations (e.g; `MAX`, `AVG`, `COUNT`) or performing scalar operations (e.g; `ABS`, `SQRT`, `UPPER`), we have functions available in the `aggregate_functions` and `scalar_functions` modules which will accept both strings or columns:
 
 ```python
-from pysqlscribe.table import PostgresTable
+from pysqlscribe.table import Table
 from pysqlscribe.aggregate_functions import max_
 from pysqlscribe.scalar_functions import upper
-table = PostgresTable(
-    "employee", "first_name", "last_name", "store_location", "salary"
-)
+
+table = Table("employee", "first_name", "last_name", "store_location", "salary", dialect="postgres")
 query = (
     table.select(upper(table.store_location), max_(table.salary))
     .group_by(table.store_location)
@@ -285,9 +254,10 @@ SELECT UPPER(store_location),MAX(salary) FROM "employee" GROUP BY "store_locatio
 ## Combining Queries
 You can combine queries using the `union`, `intersect`, and `except` methods, providing either another `Query` object or a string:
 ```python
-from pysqlscribe.query import QueryRegistry
-query_builder = QueryRegistry.get_builder("mysql")
-another_query_builder = QueryRegistry.get_builder("mysql")
+from pysqlscribe.query import Query
+
+query_builder = Query("mysql")
+another_query_builder = Query("mysql")
 query = (
     query_builder.select("test_column", "another_test_column")
     .from_("test_table")
@@ -307,10 +277,10 @@ SELECT `test_column`,`another_test_column` FROM `test_table` UNION SELECT `test_
 
 to perform `all` for each combination operation, you supply the argument `all_`:
 ```python
+from pysqlscribe.query import Query
 
-from pysqlscribe.query import QueryRegistry
-query_builder = QueryRegistry.get_builder("mysql")
-another_query_builder = QueryRegistry.get_builder("mysql")
+query_builder = Query("mysql")
+another_query_builder = Query("mysql")
 query = (
     query_builder.select("test_column", "another_test_column")
     .from_("test_table")
@@ -332,11 +302,9 @@ SELECT `test_column`,`another_test_column` FROM `test_table` UNION ALL SELECT `t
 For aliasing tables and columns, you can use the `as_` method on the `Table` or `Column` objects:
 
 ```python
-from pysqlscribe.table import PostgresTable
+from pysqlscribe.table import Table
 
-employee_table = PostgresTable(
-    "employee", "first_name", "last_name", "dept", "payroll_id"
-)
+employee_table = Table("employee", "first_name", "last_name", "dept", "payroll_id", dialect="postgres")
 query = (
     employee_table.as_("e").select(employee_table.first_name.as_("name")).build()
 )
@@ -352,10 +320,10 @@ SELECT "first_name" AS name FROM "employee" AS e
 Subqueries can be used when evaluating `Column`s in the form of a membership:
 
 ```python
-from pysqlscribe.table import MySQLTable
+from pysqlscribe.table import Table
 
-employees = MySQLTable("employees", "salary", "bonus", "department_id")
-departments = MySQLTable("departments", "id", "name", "manager_id")
+employees = Table("employees", "salary", "bonus", "department_id", dialect="mysql")
+departments = Table("departments", "id", "name", "manager_id", dialect="mysql")
 subquery = departments.select("id").where(departments.name == "Engineering")
 query = employees.select().where(employees.department_id.in_(subquery)).build()
 ```
@@ -369,9 +337,9 @@ SELECT * FROM `employees` WHERE employees.department_id IN (SELECT `id` FROM `de
 While the primary focus of this library is on building retrieval (`"SELECT"`) queries, you can also build `INSERT` queries:
 
 ```python
-from pysqlscribe.query import QueryRegistry
+from pysqlscribe.query import Query
 
-query_builder = QueryRegistry.get_builder("mysql")
+query_builder = Query("mysql")
 query = query_builder.insert(
     "test_column",
     "another_test_column",
@@ -389,9 +357,9 @@ INSERT INTO `test_table` (`test_column`,`another_test_column`) VALUES (1,2)
 While `into` and `values` are required keyword arguments, if no positional arguments (`args`) are supplied, it is omitted from the query:
 
 ```python
-from pysqlscribe.query import QueryRegistry
+from pysqlscribe.query import Query
 
-query_builder = QueryRegistry.get_builder("mysql")
+query_builder = Query("mysql")
 query = query_builder.insert(
     into="test_table",
     values=(1, 2),
@@ -408,9 +376,9 @@ INSERT INTO `test_table` VALUES (1,2)
 Multiple values can also be supplied:
 
 ```python
-from pysqlscribe.query import QueryRegistry
+from pysqlscribe.query import Query
 
-query_builder = QueryRegistry.get_builder("mysql")
+query_builder = Query("mysql")
 query = query_builder.insert(
     "test_column", "another_test_column", into="test_table", values=[(1, 2), (3, 4)]
 ).build()
@@ -424,8 +392,9 @@ INSERT INTO `test_table` (`test_column`,`another_test_column`) VALUES (1,2),(3,4
 `RETURNING` is also supported:
 
 ```python
-from pysqlscribe.query import QueryRegistry
-query_builder = QueryRegistry.get_builder("postgres")
+from pysqlscribe.query import Query
+
+query_builder = Query("postgres")
 query = (
     query_builder.insert(
         "id", "employee_name", into="employees", values=(1, "'john doe'")
@@ -437,16 +406,16 @@ query = (
 
 Output:
 
-```postgresql   
+```postgresql
 INSERT INTO "employees" ("id","employee_name") VALUES (1,'john doe') RETURNING "id","employee_name"
 ```
 
 The `Table` API offers the `insert` capability. Similar to `select`, the `into` argument is inferred from the table name:
 
 ```python
-from pysqlscribe.table import MySQLTable
+from pysqlscribe.table import Table
 
-table = MySQLTable("employees", "salary", "bonus")
+table = Table("employees", "salary", "bonus", dialect="mysql")
 query = table.insert(table.salary, table.bonus, values=(100, 200)).build()
 ```
 
@@ -461,8 +430,9 @@ By default, all identifiers are escaped using the corresponding dialect's escape
 
 
 ```python
-from pysqlscribe.query import QueryRegistry
-query_builder = QueryRegistry.get_builder("mysql").disable_escape_identifiers()
+from pysqlscribe.query import Query
+
+query_builder = Query("mysql").disable_escape_identifiers()
 query = (
     query_builder.select("test_column", "another_test_column")
     .from_("test_table")
@@ -479,9 +449,9 @@ SELECT test_column,another_test_column FROM test_table WHERE test_column = 1 AND
 If you want to switch preferences, there's a corresponding `enable_escape_identifiers` method:
 
 ```python
-from pysqlscribe.query import QueryRegistry
+from pysqlscribe.query import Query
 
-query_builder = QueryRegistry.get_builder("mysql").disable_escape_identifiers()
+query_builder = Query("mysql").disable_escape_identifiers()
 query = (
     query_builder.select("test_column", "another_test_column")
     .enable_escape_identifiers()
@@ -530,10 +500,10 @@ CREATE TABLE cool_company.employees (
 parsed = parse_create_tables(sql) # will be a dictionary of table name to table metadata e.g; columns, schema
 parsed # {'employees': {'columns': ['employee_id', 'salary', 'role'], 'schema': 'cool_company'}}
 tables = create_tables_from_parsed(
-    parsed, 
+    parsed,
     dialect="mysql"
 ) # dictionary of table name to `Table` object
-tables # {'employees': MysqlTable(name=cool_company.employees, columns=('employee_id', 'salary', 'role'))}
+tables # {'employees': Table(name=cool_company.employees, columns=('employee_id', 'salary', 'role'))}
 ```
 # Supported Dialects
 This is anticipated to grow, also there are certainly operations that are missing within dialects.
@@ -546,7 +516,7 @@ This is anticipated to grow, also there are certainly operations that are missin
 # TODO
 - [ ] Add more dialects
 - [ ] Support `OFFSET` for Oracle and SQLServer
-- [ ] Improved injection mitigation  
+- [ ] Improved injection mitigation
 - [ ] Support more aggregate and scalar functions
 - [ ] Enhance how where clauses are handled
 

--- a/README.md
+++ b/README.md
@@ -515,7 +515,6 @@ This is anticipated to grow, also there are certainly operations that are missin
 
 # TODO
 - [ ] Add more dialects
-- [ ] Support `OFFSET` for Oracle and SQLServer
 - [ ] Improved injection mitigation
 - [ ] Support more aggregate and scalar functions
 - [ ] Enhance how where clauses are handled

--- a/pysqlscribe/query.py
+++ b/pysqlscribe/query.py
@@ -1,5 +1,4 @@
-from abc import ABC
-from typing import Dict, Self
+from typing import Self
 
 from pysqlscribe.ast.base import Node
 from pysqlscribe.ast.joins import JoinType
@@ -25,12 +24,13 @@ from pysqlscribe.dialects import (
 from pysqlscribe.dialects.base import DialectRegistry
 
 
-class Query(ABC):
+class Query:
     node: Node | None = None
-    _dialect_key: str
 
-    def __init__(self):
-        self._dialect = DialectRegistry.get_dialect(self._dialect_key)
+    def __init__(self, dialect: str):
+        if dialect not in DialectRegistry.dialects:
+            raise ValueError(f"Unsupported dialect: {dialect}")
+        self._dialect = DialectRegistry.get_dialect(dialect)
 
     @property
     def dialect(self) -> Dialect:
@@ -168,39 +168,3 @@ class Query(ABC):
     def enable_escape_identifiers(self):
         self.dialect.escape_identifiers_enabled = True
         return self
-
-
-class QueryRegistry:
-    builders: Dict[str, type[Query]] = {}
-
-    @classmethod
-    def register(cls, key: str):
-        def decorator(builder_class: type[Query]) -> type[Query]:
-            cls.builders[key] = builder_class
-            return builder_class
-
-        return decorator
-
-    @classmethod
-    def get_builder(cls, key: str) -> Query:
-        return cls.builders[key]()
-
-
-@QueryRegistry.register("mysql")
-class MySQLQuery(Query):
-    _dialect_key = "mysql"
-
-
-@QueryRegistry.register("oracle")
-class OracleQuery(Query):
-    _dialect_key = "oracle"
-
-
-@QueryRegistry.register("postgres")
-class PostgreSQLQuery(Query):
-    _dialect_key = "postgres"
-
-
-@QueryRegistry.register("sqlite")
-class SQLiteQuery(Query):
-    _dialect_key = "sqlite"

--- a/pysqlscribe/schema.py
+++ b/pysqlscribe/schema.py
@@ -34,7 +34,9 @@ class Schema:
     @tables.setter
     def tables(self, tables_: list[str | Table]):
         if all(isinstance(table, str) for table in tables_):
-            tables_ = [Table.create(self.dialect)(table_name) for table_name in tables_]
+            tables_ = [
+                Table(table_name, dialect=self.dialect) for table_name in tables_
+            ]
         for table in tables_:
             setattr(self, table.table_name, table)
             table.schema = self.name

--- a/pysqlscribe/table.py
+++ b/pysqlscribe/table.py
@@ -1,94 +1,61 @@
-from abc import ABC
+from __future__ import annotations
+
 from typing import List, Self
 
 from pysqlscribe.alias import AliasMixin
 from pysqlscribe.column import Column
 from pysqlscribe.exceptions import InvalidTableNameException
-from pysqlscribe.query import QueryRegistry, JoinType
+from pysqlscribe.ast.joins import JoinType
+from pysqlscribe.query import Query
 from pysqlscribe.regex_patterns import (
     VALID_IDENTIFIER_REGEX,
 )
 
 
-class Table(ABC, AliasMixin):
-    __cache: dict[str, type["Table"]] = {}
-
-    def __init__(self, name: str, *columns, schema: str | None = None):
+class Table(Query, AliasMixin):
+    def __init__(self, name: str, *columns, dialect: str, schema: str | None = None):
+        Query.__init__(self, dialect)
         self.table_name = name
         self.schema = schema
         self.columns = columns
 
-    @classmethod
-    def create(cls, dialect: str):
-        if dialect not in QueryRegistry.builders:
-            raise ValueError(f"Unsupported dialect: {dialect}")
+    def select(self, *columns) -> Self:
+        columns = [
+            f"{column.name}{column.alias}" if isinstance(column, Column) else column
+            for column in columns
+        ]
+        table_name = f"{self.table_name}{self.alias}"
+        return super().select(*columns).from_(table_name)
 
-        class_name = f"{dialect.capitalize()}Table"
+    def order_by(self, *columns) -> Self:
+        columns = [
+            column.name if isinstance(column, Column) else column for column in columns
+        ]
+        return super().order_by(*columns)
 
-        if class_name in cls.__cache:
-            return cls.__cache[class_name]
+    def group_by(self, *columns) -> Self:
+        columns = [
+            column.name if isinstance(column, Column) else column for column in columns
+        ]
+        return super().group_by(*columns)
 
-        query_class = QueryRegistry.get_builder(dialect).__class__
+    def join(
+        self,
+        table: str | "Table",
+        join_type: str = JoinType.INNER,
+        condition: str | None = None,
+    ) -> Self:
+        if isinstance(table, Table):
+            table = f"{table.table_name}{table.alias}"
+        return super().join(table, join_type, condition)
 
-        class DynamicTable(query_class, Table):
-            def __init__(self, name: str, *fields, schema: str | None = None):
-                query_class.__init__(self)
-                Table.__init__(self, name, *fields, schema=schema)
-
-            def select(self, *columns):
-                columns = [
-                    f"{column.name}{column.alias}"
-                    if isinstance(column, Column)
-                    else column
-                    for column in columns
-                ]
-                table_name = f"{self.table_name}{self.alias}"
-                return super().select(*columns).from_(table_name)
-
-            def order_by(self, *columns):
-                columns = [
-                    column.name if isinstance(column, Column) else column
-                    for column in columns
-                ]
-                return super().order_by(*columns)
-
-            def group_by(self, *columns):
-                columns = [
-                    column.name if isinstance(column, Column) else column
-                    for column in columns
-                ]
-                return super().group_by(*columns)
-
-            def join(
-                self,
-                table: str | Table,
-                join_type: str = JoinType.INNER,
-                condition: str | None = None,
-            ) -> Self:
-                if isinstance(table, Table):
-                    table = f"{table.table_name}{table.alias}"
-                return super().join(table, join_type, condition)
-
-            def insert(self, *columns, **kwargs) -> Self:
-                """
-                Override the insert method to ensure it uses the correct table name.
-                """
-                columns = [
-                    column.name if isinstance(column, Column) else column
-                    for column in columns
-                ]
-                return super().insert(
-                    *columns, into=self.table_name, values=kwargs.get("values")
-                )
-
-            def __repr__(self):
-                return f"{self.__class__.__name__}(name={self.table_name}, columns={self.columns})"
-
-        # Set a meaningful class name
-        DynamicTable.__name__ = class_name
-        cls.__cache[class_name] = DynamicTable
-
-        return DynamicTable
+    def insert(self, *columns, **kwargs) -> Self:
+        columns = [
+            column.name if isinstance(column, Column) else column for column in columns
+        ]
+        return super().insert(
+            *columns, into=self.table_name, values=kwargs.get("values")
+        )
 
     @property
     def table_name(self):
@@ -127,8 +94,7 @@ class Table(ABC, AliasMixin):
         self.columns = self.columns
         return self
 
-
-MySQLTable = Table.create("mysql")
-OracleTable = Table.create("oracle")
-PostgresTable = Table.create("postgres")
-SqliteTable = Table.create("sqlite")
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(name={self.table_name}, columns={self.columns})"
+        )

--- a/pysqlscribe/utils/ddl_loader.py
+++ b/pysqlscribe/utils/ddl_loader.py
@@ -13,11 +13,13 @@ class InvalidPathException(Exception):
 def create_tables_from_parsed(
     parsed: dict[str, dict[str, list[str] | str]], dialect: str
 ) -> dict[str, Table]:
-    TableClass = Table.create(dialect)
     tables = {}
     for table_name, table_metadata in parsed.items():
-        tables[table_name] = TableClass(
-            table_name, *table_metadata["columns"], schema=table_metadata.get("schema")
+        tables[table_name] = Table(
+            table_name,
+            *table_metadata["columns"],
+            dialect=dialect,
+            schema=table_metadata.get("schema"),
         )
     return tables
 

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -1,12 +1,12 @@
 import pytest
 
-from pysqlscribe.query import JoinType
-from pysqlscribe.table import PostgresTable
+from pysqlscribe.ast.joins import JoinType
+from pysqlscribe.table import Table
 
 
 def test_alias():
-    employee_table = PostgresTable(
-        "employee", "first_name", "last_name", "dept", "payroll_id"
+    employee_table = Table(
+        "employee", "first_name", "last_name", "dept", "payroll_id", dialect="postgres"
     )
     query = (
         employee_table.as_("e").select(employee_table.first_name.as_("name")).build()
@@ -15,8 +15,8 @@ def test_alias():
 
 
 def test_invalid_alias():
-    employee_table = PostgresTable(
-        "employee", "first_name", "last_name", "dept", "payroll_id"
+    employee_table = Table(
+        "employee", "first_name", "last_name", "dept", "payroll_id", dialect="postgres"
     )
     with pytest.raises(ValueError):
         employee_table.as_("$something$not$allowed").select(
@@ -28,10 +28,10 @@ def test_invalid_alias():
     "join_type", [JoinType.INNER, JoinType.OUTER, JoinType.LEFT, JoinType.RIGHT]
 )
 def test_table_join_with_alias(join_type: JoinType):
-    employee_table = PostgresTable(
-        "employee", "first_name", "last_name", "dept", "payroll_id"
+    employee_table = Table(
+        "employee", "first_name", "last_name", "dept", "payroll_id", dialect="postgres"
     )
-    payroll_table = PostgresTable("payroll", "id", "salary", "category")
+    payroll_table = Table("payroll", "id", "salary", "category", dialect="postgres")
     query = (
         employee_table.as_("e")
         .select(

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -27,7 +27,7 @@ from pysqlscribe.scalar_functions import (
     acos,
     asin,
 )
-from pysqlscribe.table import PostgresTable
+from pysqlscribe.table import Table
 
 
 @pytest.mark.parametrize(
@@ -39,8 +39,13 @@ from pysqlscribe.table import PostgresTable
     ],
 )
 def test_aggregate_functions(agg_function, agg_str):
-    table = PostgresTable(
-        "employee", "first_name", "last_name", "store_location", "salary"
+    table = Table(
+        "employee",
+        "first_name",
+        "last_name",
+        "store_location",
+        "salary",
+        dialect="postgres",
     )
     query = (
         table.select(table.store_location, agg_function(table.salary))
@@ -55,8 +60,13 @@ def test_aggregate_functions(agg_function, agg_str):
 
 @pytest.mark.parametrize("agg_column", [1, "first_name"])
 def test_agg_function_with_non_column_object(agg_column):
-    table = PostgresTable(
-        "employee", "first_name", "last_name", "store_location", "salary"
+    table = Table(
+        "employee",
+        "first_name",
+        "last_name",
+        "store_location",
+        "salary",
+        dialect="postgres",
     )
     query = (
         table.select(table.store_location, count(agg_column))
@@ -93,13 +103,13 @@ def test_agg_function_with_non_column_object(agg_column):
     ],
 )
 def test_scalar_functions(scalar_function, str_function):
-    payroll_table = PostgresTable("payroll", "id", "salary", "category")
+    payroll_table = Table("payroll", "id", "salary", "category", dialect="postgres")
     query = payroll_table.select(scalar_function(payroll_table.salary)).build()
     assert query == f'SELECT {str_function}(salary) FROM "payroll"'
 
 
 def test_concat():
-    payroll_table = PostgresTable("payroll", "id", "salary", "category")
+    payroll_table = Table("payroll", "id", "salary", "category", dialect="postgres")
     query = payroll_table.select(concat(payroll_table.salary, "USD")).build()
     assert query == "SELECT CONCAT(salary, 'USD') FROM \"payroll\""
 
@@ -111,8 +121,8 @@ def test_concat():
 
 
 def test_concat_with_columns():
-    payroll_table = PostgresTable(
-        "payroll", "first_name", "last_name", "salary", "category"
+    payroll_table = Table(
+        "payroll", "first_name", "last_name", "salary", "category", dialect="postgres"
     )
     query = payroll_table.select(
         concat(payroll_table.first_name, payroll_table.last_name).as_("full_name")
@@ -121,7 +131,7 @@ def test_concat_with_columns():
 
 
 def test_power_with_column():
-    payroll_table = PostgresTable("payroll", "id", "salary", "category")
+    payroll_table = Table("payroll", "id", "salary", "category", dialect="postgres")
     query = payroll_table.select(power(payroll_table.salary, 2)).build()
     assert query == 'SELECT POWER(salary, 2) FROM "payroll"'
     query = payroll_table.select(power(2, payroll_table.salary)).build()
@@ -130,7 +140,7 @@ def test_power_with_column():
 
 @pytest.mark.parametrize("base,exponent", [(2, 3), ("2", 3), (2, "3")])
 def test_power_with_non_column(base, exponent):
-    payroll_table = PostgresTable("payroll", "id", "salary", "category")
+    payroll_table = Table("payroll", "id", "salary", "category", dialect="postgres")
     query = payroll_table.select(power(base, exponent)).build()
     assert query == f'SELECT POWER({base}, {exponent}) FROM "payroll"'
 
@@ -140,7 +150,7 @@ def test_power_with_non_column(base, exponent):
     [(ScalarFunctions.ROUND, round_), (ScalarFunctions.TRUNC, trunc)],
 )
 def test_rounding_functions(rounding_function_name, rounding_function):
-    payroll_table = PostgresTable("payroll", "id", "salary", "category")
+    payroll_table = Table("payroll", "id", "salary", "category", dialect="postgres")
     query = payroll_table.select(rounding_function(payroll_table.salary)).build()
     assert query == f'SELECT {rounding_function_name}(salary) FROM "payroll"'
 
@@ -152,7 +162,7 @@ def test_rounding_functions(rounding_function_name, rounding_function):
 
 
 def test_nullif():
-    payroll_table = PostgresTable("payroll", "id", "salary", "category")
+    payroll_table = Table("payroll", "id", "salary", "category", dialect="postgres")
     query = payroll_table.select(nullif(payroll_table.salary, 0)).build()
     assert query == 'SELECT NULLIF(salary, 0) FROM "payroll"'
 
@@ -164,7 +174,7 @@ def test_nullif():
 
 
 def test_atan2():
-    payroll_table = PostgresTable("payroll", "id", "salary", "category")
+    payroll_table = Table("payroll", "id", "salary", "category", dialect="postgres")
     query = payroll_table.select(atan2(payroll_table.salary, 100)).build()
     assert query == 'SELECT ATAN2(salary, 100) FROM "payroll"'
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -3,10 +3,8 @@ from itertools import product
 import pytest
 
 from pysqlscribe.exceptions import InvalidJoinException
-from pysqlscribe.query import (
-    QueryRegistry,
-    JoinType,
-)
+from pysqlscribe.ast.joins import JoinType
+from pysqlscribe.query import Query
 from pysqlscribe.renderers.base import UNION, EXCEPT, INTERSECT
 
 
@@ -16,7 +14,7 @@ from pysqlscribe.renderers.base import UNION, EXCEPT, INTERSECT
     ids=["single field", "multiple fields"],
 )
 def test_select_query(fields):
-    query_builder = QueryRegistry.get_builder("mysql")
+    query_builder = Query("mysql")
     query = query_builder.select(*fields).from_("test_table").build()
     fields = [
         query_builder.dialect.escape_identifier(identifier) for identifier in fields
@@ -25,7 +23,7 @@ def test_select_query(fields):
 
 
 def test_select_query_no_columns():
-    query_builder = QueryRegistry.get_builder("mysql")
+    query_builder = Query("mysql")
     query = query_builder.select().from_("test_table").build()
     assert query == "SELECT * FROM `test_table`"
 
@@ -35,7 +33,7 @@ def test_select_query_no_columns():
     [("mysql", "LIMIT {limit}"), ("oracle", "FETCH NEXT {limit} ROWS ONLY")],
 )
 def test_select_query_with_limit(dialect, syntax):
-    query_builder = QueryRegistry.get_builder(dialect)
+    query_builder = Query(dialect)
     query = query_builder.select("test_column").from_("test_table").limit(10).build()
     assert (
         query
@@ -44,7 +42,7 @@ def test_select_query_with_limit(dialect, syntax):
 
 
 def test_select_query_with_limit_and_offset():
-    query_builder = QueryRegistry.get_builder("postgres")
+    query_builder = Query("postgres")
     query = (
         query_builder.select("test_column")
         .from_("test_table")
@@ -59,7 +57,7 @@ def test_select_query_with_limit_and_offset():
 
 
 def test_select_query_with_order_by():
-    query_builder = QueryRegistry.get_builder("mysql")
+    query_builder = Query("mysql")
     query = (
         query_builder.select("test_column", "another_test_column")
         .from_("test_table")
@@ -73,7 +71,7 @@ def test_select_query_with_order_by():
 
 
 def test_where_clause():
-    query_builder = QueryRegistry.get_builder("mysql")
+    query_builder = Query("mysql")
     query = (
         query_builder.select("test_column", "another_test_column")
         .from_("test_table")
@@ -87,7 +85,7 @@ def test_where_clause():
 
 
 def test_group_by_having():
-    query_builder = QueryRegistry.get_builder("sqlite")
+    query_builder = Query("sqlite")
     query = (
         query_builder.select(
             "product_line", "AVG(unit_price)", "SUM(quantity)", "SUM(total)"
@@ -107,7 +105,7 @@ def test_group_by_having():
     "join_type", [JoinType.INNER, JoinType.OUTER, JoinType.LEFT, JoinType.RIGHT]
 )
 def test_joins_with_conditions(join_type: JoinType):
-    query_builder = QueryRegistry.get_builder("oracle")
+    query_builder = Query("oracle")
     query_builder.select("employee_id", "store_location").from_("employees").join(
         "payroll", join_type, "employees.payroll_id = payroll.id"
     )
@@ -120,7 +118,7 @@ def test_joins_with_conditions(join_type: JoinType):
 
 @pytest.mark.parametrize("join_type", [JoinType.NATURAL, JoinType.CROSS])
 def test_joins_no_condition(join_type: JoinType):
-    query_builder = QueryRegistry.get_builder("oracle")
+    query_builder = Query("oracle")
     query_builder.select("employee_id", "store_location").from_("employees").join(
         "payroll", join_type
     )
@@ -132,7 +130,7 @@ def test_joins_no_condition(join_type: JoinType):
 
 
 def test_invalid_join():
-    query_builder = QueryRegistry.get_builder("oracle")
+    query_builder = Query("oracle")
     with pytest.raises(InvalidJoinException):
         query_builder.select("employee_id", "store_location").from_("employees").join(
             "payroll", JoinType.NATURAL, "employees.payroll_id = payroll.id"
@@ -143,7 +141,7 @@ def test_invalid_join():
     "join_type", [JoinType.INNER, JoinType.OUTER, JoinType.LEFT, JoinType.RIGHT]
 )
 def test_join_where_with_conditions(join_type: JoinType):
-    query_builder = QueryRegistry.get_builder("oracle")
+    query_builder = Query("oracle")
     query_builder.select("employee_id", "store_location").from_("employees").join(
         "payroll", join_type, "employees.payroll_id = payroll.id"
     ).where("employee.salary > 10000")
@@ -155,7 +153,7 @@ def test_join_where_with_conditions(join_type: JoinType):
 
 
 def test_disable_escape_identifier():
-    query_builder = QueryRegistry.get_builder("mysql").disable_escape_identifiers()
+    query_builder = Query("mysql").disable_escape_identifiers()
     query = (
         query_builder.select("test_column", "another_test_column")
         .from_("test_table")
@@ -169,7 +167,7 @@ def test_disable_escape_identifier():
 
 
 def test_escape_identifier_switch_preferences():
-    query_builder = QueryRegistry.get_builder("mysql").disable_escape_identifiers()
+    query_builder = Query("mysql").disable_escape_identifiers()
     query = (
         query_builder.select("test_column", "another_test_column")
         .enable_escape_identifiers()
@@ -185,7 +183,7 @@ def test_escape_identifier_switch_preferences():
 
 def test_disable_escape_identifier_with_environment_variable(monkeypatch):
     monkeypatch.setenv("PYSQLSCRIBE_ESCAPE_IDENTIFIERS", "False")
-    query_builder = QueryRegistry.get_builder("mysql")
+    query_builder = Query("mysql")
     query = (
         query_builder.select("test_column", "another_test_column")
         .from_("test_table")
@@ -200,8 +198,8 @@ def test_disable_escape_identifier_with_environment_variable(monkeypatch):
 
 @pytest.mark.parametrize("all_", [True, False])
 def test_union(all_):
-    query_builder = QueryRegistry.get_builder("mysql")
-    another_query_builder = QueryRegistry.get_builder("mysql")
+    query_builder = Query("mysql")
+    another_query_builder = Query("mysql")
     query = (
         query_builder.select("test_column")
         .from_("test_table")
@@ -224,8 +222,8 @@ def test_union(all_):
     "all_, combine_operation", product([True, False], [UNION, EXCEPT, INTERSECT])
 )
 def test_combine_operations(all_, combine_operation):
-    query_builder = QueryRegistry.get_builder("mysql")
-    another_query_builder = QueryRegistry.get_builder("mysql")
+    query_builder = Query("mysql")
+    another_query_builder = Query("mysql")
     query = query_builder.select("test_column").from_("test_table")
     another_query = another_query_builder.select("another_test_column").from_(
         "another_test_table"
@@ -245,7 +243,7 @@ def test_combine_operations(all_, combine_operation):
 
 
 def test_insert():
-    query_builder = QueryRegistry.get_builder("mysql")
+    query_builder = Query("mysql")
     query = query_builder.insert(
         "test_column",
         "another_test_column",
@@ -259,7 +257,7 @@ def test_insert():
 
 
 def test_insert_no_cols_query():
-    query_builder = QueryRegistry.get_builder("mysql")
+    query_builder = Query("mysql")
     query = query_builder.insert(
         into="test_table",
         values=(1, 2),
@@ -268,7 +266,7 @@ def test_insert_no_cols_query():
 
 
 def test_insert_multiple_values():
-    query_builder = QueryRegistry.get_builder("mysql")
+    query_builder = Query("mysql")
     query = query_builder.insert(
         "test_column", "another_test_column", into="test_table", values=[(1, 2), (3, 4)]
     ).build()
@@ -279,7 +277,7 @@ def test_insert_multiple_values():
 
 
 def test_insert_column_and_values_mismatch():
-    query_builder = QueryRegistry.get_builder("mysql")
+    query_builder = Query("mysql")
     with pytest.raises(AssertionError):
         query_builder.insert(
             "test_column", "another_test_column", into="test_table", values=(1,)
@@ -287,14 +285,14 @@ def test_insert_column_and_values_mismatch():
 
 
 def test_insert_no_table_provided():
-    query_builder = QueryRegistry.get_builder("mysql")
+    query_builder = Query("mysql")
     with pytest.raises(ValueError):
         query_builder.insert("test_column", "another_test_column", values=(1, 2))
 
 
 @pytest.mark.parametrize("return_value", ["id", "*"])
 def test_insert_with_returning(return_value):
-    query_builder = QueryRegistry.get_builder("postgres")
+    query_builder = Query("postgres")
     query = (
         query_builder.insert(
             "id", "employee_name", into="employees", values=(1, "'john doe'")
@@ -311,7 +309,7 @@ def test_insert_with_returning(return_value):
 
 
 def test_insert_with_returning_multiple_values():
-    query_builder = QueryRegistry.get_builder("postgres")
+    query_builder = Query("postgres")
     query = (
         query_builder.insert(
             "id", "employee_name", into="employees", values=(1, "'john doe'")
@@ -326,7 +324,7 @@ def test_insert_with_returning_multiple_values():
 
 
 def test_insert_returning_empty():
-    query_builder = QueryRegistry.get_builder("postgres")
+    query_builder = Query("postgres")
     query = (
         query_builder.insert(
             "id", "employee_name", into="employees", values=(1, "'john doe'")
@@ -338,3 +336,8 @@ def test_insert_returning_empty():
         query
         == 'INSERT INTO "employees" ("id", "employee_name") VALUES (1,\'john doe\') RETURNING *'
     )
+
+
+def test_invalid_dialect():
+    with pytest.raises(ValueError):
+        Query("non-existent-dialect")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,5 +1,5 @@
 from pysqlscribe.schema import Schema
-from pysqlscribe.table import Table, OracleTable, PostgresTable, SqliteTable
+from pysqlscribe.table import Table
 
 
 def test_schema_create_tables():
@@ -7,7 +7,7 @@ def test_schema_create_tables():
         "test_schema", ["test_table", "another_test_table"], dialect="postgres"
     )
     assert len(schema.tables) == 2
-    assert all(isinstance(table, PostgresTable) for table in schema.tables)
+    assert all(isinstance(table, Table) for table in schema.tables)
     assert all(table.table_name.startswith("test_schema") for table in schema.tables)
     assert hasattr(schema, "test_table")
 
@@ -16,15 +16,22 @@ def test_schema_dialect_environment_provided(monkeypatch):
     monkeypatch.setenv("PYSQLSCRIBE_BUILDER_DIALECT", "sqlite")
     schema = Schema("test_schema", ["test_table", "another_test_table"])
     assert len(schema.tables) == 2
-    assert all(isinstance(table, SqliteTable) for table in schema.tables)
+    assert all(isinstance(table, Table) for table in schema.tables)
     assert all(table.table_name.startswith("test_schema") for table in schema.tables)
     assert hasattr(schema, "test_table")
 
 
 def test_schema_supply_tables():
     tables = [
-        OracleTable("cards", "stars", "card_name", "card_description", "card_cost"),
-        OracleTable("regions", "region_id", "region_name"),
+        Table(
+            "cards",
+            "stars",
+            "card_name",
+            "card_description",
+            "card_cost",
+            dialect="oracle",
+        ),
+        Table("regions", "region_id", "region_name", dialect="oracle"),
     ]
     schema = Schema("kaibacorp", tables)
     assert len(schema.tables) == 2

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,18 +1,13 @@
 import pytest
 
 from pysqlscribe.aggregate_functions import avg
-from pysqlscribe.query import JoinType
+from pysqlscribe.ast.joins import JoinType
 
-from pysqlscribe.table import (
-    MySQLTable,
-    OracleTable,
-    Table,
-    PostgresTable,
-)
+from pysqlscribe.table import Table
 
 
 def test_table_select():
-    table = MySQLTable("test_table", "test_column", "another_test_column")
+    table = Table("test_table", "test_column", "another_test_column", dialect="mysql")
     query = table.select("test_column").build()
     assert query == "SELECT `test_column` FROM `test_table`"
     assert hasattr(table, "test_column")
@@ -20,8 +15,12 @@ def test_table_select():
 
 
 def test_table_with_schema():
-    table = MySQLTable(
-        "test_table", "test_column", "another_test_column", schema="test_schema"
+    table = Table(
+        "test_table",
+        "test_column",
+        "another_test_column",
+        dialect="mysql",
+        schema="test_schema",
     )
     query = table.select("test_column", "another_test_column").build()
     assert (
@@ -31,19 +30,14 @@ def test_table_with_schema():
     assert table.table_name == "test_schema.test_table"
 
 
-def test_create_existing_table_type():
-    oracle_table_class = Table.create("oracle")
-    assert oracle_table_class == OracleTable
-
-
 def test_create_invalid_dialect():
     with pytest.raises(ValueError):
-        Table.create("non-existent-dialect")
+        Table("test_table", dialect="non-existent-dialect")
 
 
 def test_table_reassign_columns():
     old_columns = ["employees", "locations"]
-    table = OracleTable("capsule_corp", *old_columns)
+    table = Table("capsule_corp", *old_columns, dialect="oracle")
     new_columns = ["peons", "orders", "suppliers", "regions"]
     table.columns = new_columns
     assert all(hasattr(table, column) for column in new_columns)
@@ -51,7 +45,7 @@ def test_table_reassign_columns():
 
 
 def test_table_where_clause_fixed_value():
-    table = MySQLTable("test_table", "test_column")
+    table = Table("test_table", "test_column", dialect="mysql")
     query = table.select("test_column").where(table.test_column > 5).build()
     assert (
         query
@@ -60,7 +54,7 @@ def test_table_where_clause_fixed_value():
 
 
 def test_table_where_clause_other_column():
-    table = MySQLTable("test_table", "test_column", "other_test_column")
+    table = Table("test_table", "test_column", "other_test_column", dialect="mysql")
     query = (
         table.select(table.test_column)
         .where(table.test_column > table.other_test_column)
@@ -73,7 +67,9 @@ def test_table_where_clause_other_column():
 
 
 def test_table_select_all():
-    table = PostgresTable("employee", "first_name", "last_name", "dept", "salary")
+    table = Table(
+        "employee", "first_name", "last_name", "dept", "salary", dialect="postgres"
+    )
     query = table.select("*").where(table.dept == "Sales").build()
     assert query == "SELECT * FROM \"employee\" WHERE employee.dept = 'Sales'"
 
@@ -82,10 +78,10 @@ def test_table_select_all():
     "join_type", [JoinType.INNER, JoinType.OUTER, JoinType.LEFT, JoinType.RIGHT]
 )
 def test_table_join_with_conditions(join_type: JoinType):
-    employee_table = PostgresTable(
-        "employee", "first_name", "last_name", "dept", "payroll_id"
+    employee_table = Table(
+        "employee", "first_name", "last_name", "dept", "payroll_id", dialect="postgres"
     )
-    payroll_table = PostgresTable("payroll", "id", "salary", "category")
+    payroll_table = Table("payroll", "id", "salary", "category", dialect="postgres")
     query = (
         employee_table.select(
             employee_table.first_name, employee_table.last_name, employee_table.dept
@@ -101,10 +97,10 @@ def test_table_join_with_conditions(join_type: JoinType):
 
 @pytest.mark.parametrize("join_type", [JoinType.NATURAL, JoinType.CROSS])
 def test_table_join_without_conditions(join_type: JoinType):
-    employee_table = PostgresTable(
-        "employee", "first_name", "last_name", "dept", "payroll_id"
+    employee_table = Table(
+        "employee", "first_name", "last_name", "dept", "payroll_id", dialect="postgres"
     )
-    payroll_table = PostgresTable("payroll", "id", "salary", "category")
+    payroll_table = Table("payroll", "id", "salary", "category", dialect="postgres")
     query = (
         employee_table.select(
             employee_table.first_name, employee_table.last_name, employee_table.dept
@@ -119,7 +115,7 @@ def test_table_join_without_conditions(join_type: JoinType):
 
 
 def test_column_operations():
-    table = MySQLTable("employees", "salary", "bonus", "lti")
+    table = Table("employees", "salary", "bonus", "lti", dialect="mysql")
     query = table.select((table.salary * 0.75).as_("salary_after_taxes")).build()
     assert (
         query == "SELECT employees.salary * 0.75 AS salary_after_taxes FROM `employees`"
@@ -127,7 +123,7 @@ def test_column_operations():
 
 
 def test_add_two_columns():
-    table = MySQLTable("employees", "salary", "bonus", "lti")
+    table = Table("employees", "salary", "bonus", "lti", dialect="mysql")
     query = table.select((table.salary + table.bonus).as_("total_compensation")).build()
     assert (
         query
@@ -136,7 +132,7 @@ def test_add_two_columns():
 
 
 def test_add_more_than_two_columns():
-    table = MySQLTable("employees", "salary", "bonus", "lti")
+    table = Table("employees", "salary", "bonus", "lti", dialect="mysql")
     query = table.select(
         (table.salary + table.bonus + table.lti).as_("total_compensation")
     ).build()
@@ -147,7 +143,7 @@ def test_add_more_than_two_columns():
 
 
 def test_operations_columns_and_numerics():
-    table = MySQLTable("employees", "salary", "bonus")
+    table = Table("employees", "salary", "bonus", dialect="mysql")
     query = table.select(
         (table.salary * 1.25 + table.bonus).as_("total_compensation")
     ).build()
@@ -158,14 +154,14 @@ def test_operations_columns_and_numerics():
 
 
 def test_insert():
-    table = MySQLTable("employees", "salary", "bonus")
+    table = Table("employees", "salary", "bonus", dialect="mysql")
     query = table.insert(table.salary, table.bonus, values=(100, 200)).build()
     assert query == "INSERT INTO `employees` (`salary`, `bonus`) VALUES (100,200)"
 
 
 def test_subquery_columns():
-    employees = MySQLTable("employees", "salary", "bonus", "department_id")
-    departments = MySQLTable("departments", "id", "name", "manager_id")
+    employees = Table("employees", "salary", "bonus", "department_id", dialect="mysql")
+    departments = Table("departments", "id", "name", "manager_id", dialect="mysql")
     subquery = departments.select("id").where(departments.name == "Engineering")
     query = employees.select().where(employees.department_id.in_(subquery)).build()
     assert (
@@ -175,7 +171,7 @@ def test_subquery_columns():
 
 
 def test_groupby_having():
-    table = MySQLTable("employees", "salary", "department_id")
+    table = Table("employees", "salary", "department_id", dialect="mysql")
     query = (
         table.select(table.department_id, avg(table.salary).as_("avg_salary"))
         .group_by(table.department_id)
@@ -189,7 +185,7 @@ def test_groupby_having():
 
 
 def test_rename_table():
-    table = MySQLTable("old_table_name", "column1", "column2")
+    table = Table("old_table_name", "column1", "column2", dialect="mysql")
     table.table_name = "new_table_name"
     query = table.select("column1", "column2").where(table.column1 > 1).build()
     assert (

--- a/uv.lock
+++ b/uv.lock
@@ -1,94 +1,95 @@
 version = 1
+revision = 3
 requires-python = ">=3.11"
 
 [[package]]
 name = "cfgv"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114 }
+sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114, upload-time = "2023-08-12T20:38:17.776Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249 },
+    { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249, upload-time = "2023-08-12T20:38:16.269Z" },
 ]
 
 [[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
 ]
 
 [[package]]
 name = "distlib"
 version = "0.3.9"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/dd/1bec4c5ddb504ca60fc29472f3d27e8d4da1257a854e1d96742f15c1d02d/distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403", size = 613923 }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/dd/1bec4c5ddb504ca60fc29472f3d27e8d4da1257a854e1d96742f15c1d02d/distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403", size = 613923, upload-time = "2024-10-09T18:35:47.551Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87", size = 468973 },
+    { url = "https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87", size = 468973, upload-time = "2024-10-09T18:35:44.272Z" },
 ]
 
 [[package]]
 name = "filelock"
 version = "3.17.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dc/9c/0b15fb47b464e1b663b1acd1253a062aa5feecb07d4e597daea542ebd2b5/filelock-3.17.0.tar.gz", hash = "sha256:ee4e77401ef576ebb38cd7f13b9b28893194acc20a8e68e18730ba9c0e54660e", size = 18027 }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/9c/0b15fb47b464e1b663b1acd1253a062aa5feecb07d4e597daea542ebd2b5/filelock-3.17.0.tar.gz", hash = "sha256:ee4e77401ef576ebb38cd7f13b9b28893194acc20a8e68e18730ba9c0e54660e", size = 18027, upload-time = "2025-01-21T20:04:49.099Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/ec/00d68c4ddfedfe64159999e5f8a98fb8442729a63e2077eb9dcd89623d27/filelock-3.17.0-py3-none-any.whl", hash = "sha256:533dc2f7ba78dc2f0f531fc6c4940addf7b70a481e269a5a3b93be94ffbe8338", size = 16164 },
+    { url = "https://files.pythonhosted.org/packages/89/ec/00d68c4ddfedfe64159999e5f8a98fb8442729a63e2077eb9dcd89623d27/filelock-3.17.0-py3-none-any.whl", hash = "sha256:533dc2f7ba78dc2f0f531fc6c4940addf7b70a481e269a5a3b93be94ffbe8338", size = 16164, upload-time = "2025-01-21T20:04:47.734Z" },
 ]
 
 [[package]]
 name = "identify"
 version = "2.6.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/bf/c68c46601bacd4c6fb4dd751a42b6e7087240eaabc6487f2ef7a48e0e8fc/identify-2.6.6.tar.gz", hash = "sha256:7bec12768ed44ea4761efb47806f0a41f86e7c0a5fdf5950d4648c90eca7e251", size = 99217 }
+sdist = { url = "https://files.pythonhosted.org/packages/82/bf/c68c46601bacd4c6fb4dd751a42b6e7087240eaabc6487f2ef7a48e0e8fc/identify-2.6.6.tar.gz", hash = "sha256:7bec12768ed44ea4761efb47806f0a41f86e7c0a5fdf5950d4648c90eca7e251", size = 99217, upload-time = "2025-01-20T20:38:02.989Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/a1/68a395c17eeefb04917034bd0a1bfa765e7654fa150cca473d669aa3afb5/identify-2.6.6-py2.py3-none-any.whl", hash = "sha256:cbd1810bce79f8b671ecb20f53ee0ae8e86ae84b557de31d89709dc2a48ba881", size = 99083 },
+    { url = "https://files.pythonhosted.org/packages/74/a1/68a395c17eeefb04917034bd0a1bfa765e7654fa150cca473d669aa3afb5/identify-2.6.6-py2.py3-none-any.whl", hash = "sha256:cbd1810bce79f8b671ecb20f53ee0ae8e86ae84b557de31d89709dc2a48ba881", size = 99083, upload-time = "2025-01-20T20:38:00.261Z" },
 ]
 
 [[package]]
 name = "iniconfig"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646, upload-time = "2023-01-07T11:08:11.254Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
+    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892, upload-time = "2023-01-07T11:08:09.864Z" },
 ]
 
 [[package]]
 name = "nodeenv"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
 ]
 
 [[package]]
 name = "packaging"
 version = "24.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950, upload-time = "2024-11-08T09:47:47.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451, upload-time = "2024-11-08T09:47:44.722Z" },
 ]
 
 [[package]]
 name = "platformdirs"
 version = "4.3.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/fc/128cc9cb8f03208bdbf93d3aa862e16d376844a14f9a0ce5cf4507372de4/platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907", size = 21302 }
+sdist = { url = "https://files.pythonhosted.org/packages/13/fc/128cc9cb8f03208bdbf93d3aa862e16d376844a14f9a0ce5cf4507372de4/platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907", size = 21302, upload-time = "2024-09-17T19:06:50.688Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/a6/bc1012356d8ece4d66dd75c4b9fc6c1f6650ddd5991e421177d9f8f671be/platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb", size = 18439 },
+    { url = "https://files.pythonhosted.org/packages/3c/a6/bc1012356d8ece4d66dd75c4b9fc6c1f6650ddd5991e421177d9f8f671be/platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb", size = 18439, upload-time = "2024-09-17T19:06:49.212Z" },
 ]
 
 [[package]]
 name = "pluggy"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955, upload-time = "2024-04-20T21:34:42.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556, upload-time = "2024-04-20T21:34:40.434Z" },
 ]
 
 [[package]]
@@ -102,14 +103,14 @@ dependencies = [
     { name = "pyyaml" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/13/b62d075317d8686071eb843f0bb1f195eb332f48869d3c31a4c6f1e063ac/pre_commit-4.1.0.tar.gz", hash = "sha256:ae3f018575a588e30dfddfab9a05448bfbd6b73d78709617b5a2b853549716d4", size = 193330 }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/13/b62d075317d8686071eb843f0bb1f195eb332f48869d3c31a4c6f1e063ac/pre_commit-4.1.0.tar.gz", hash = "sha256:ae3f018575a588e30dfddfab9a05448bfbd6b73d78709617b5a2b853549716d4", size = 193330, upload-time = "2025-01-20T18:31:48.681Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/b3/df14c580d82b9627d173ceea305ba898dca135feb360b6d84019d0803d3b/pre_commit-4.1.0-py2.py3-none-any.whl", hash = "sha256:d29e7cb346295bcc1cc75fc3e92e343495e3ea0196c9ec6ba53f49f10ab6ae7b", size = 220560 },
+    { url = "https://files.pythonhosted.org/packages/43/b3/df14c580d82b9627d173ceea305ba898dca135feb360b6d84019d0803d3b/pre_commit-4.1.0-py2.py3-none-any.whl", hash = "sha256:d29e7cb346295bcc1cc75fc3e92e343495e3ea0196c9ec6ba53f49f10ab6ae7b", size = 220560, upload-time = "2025-01-20T18:31:47.319Z" },
 ]
 
 [[package]]
 name = "pysqlscribe"
-version = "0.7.0"
+version = "0.10.2"
 source = { editable = "." }
 
 [package.dev-dependencies]
@@ -138,69 +139,69 @@ dependencies = [
     { name = "packaging" },
     { name = "pluggy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
+sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919, upload-time = "2024-12-01T12:54:25.98Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
+    { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083, upload-time = "2024-12-01T12:54:19.735Z" },
 ]
 
 [[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631 }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/aa/7af4e81f7acba21a4c6be026da38fd2b872ca46226673c89a758ebdc4fd2/PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774", size = 184612 },
-    { url = "https://files.pythonhosted.org/packages/8b/62/b9faa998fd185f65c1371643678e4d58254add437edb764a08c5a98fb986/PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee", size = 172040 },
-    { url = "https://files.pythonhosted.org/packages/ad/0c/c804f5f922a9a6563bab712d8dcc70251e8af811fce4524d57c2c0fd49a4/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c", size = 736829 },
-    { url = "https://files.pythonhosted.org/packages/51/16/6af8d6a6b210c8e54f1406a6b9481febf9c64a3109c541567e35a49aa2e7/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317", size = 764167 },
-    { url = "https://files.pythonhosted.org/packages/75/e4/2c27590dfc9992f73aabbeb9241ae20220bd9452df27483b6e56d3975cc5/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85", size = 762952 },
-    { url = "https://files.pythonhosted.org/packages/9b/97/ecc1abf4a823f5ac61941a9c00fe501b02ac3ab0e373c3857f7d4b83e2b6/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4", size = 735301 },
-    { url = "https://files.pythonhosted.org/packages/45/73/0f49dacd6e82c9430e46f4a027baa4ca205e8b0a9dce1397f44edc23559d/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e", size = 756638 },
-    { url = "https://files.pythonhosted.org/packages/22/5f/956f0f9fc65223a58fbc14459bf34b4cc48dec52e00535c79b8db361aabd/PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5", size = 143850 },
-    { url = "https://files.pythonhosted.org/packages/ed/23/8da0bbe2ab9dcdd11f4f4557ccaf95c10b9811b13ecced089d43ce59c3c8/PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44", size = 161980 },
-    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873 },
-    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302 },
-    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154 },
-    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223 },
-    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542 },
-    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164 },
-    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611 },
-    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591 },
-    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338 },
-    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309 },
-    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679 },
-    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428 },
-    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361 },
-    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523 },
-    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660 },
-    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597 },
-    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527 },
-    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446 },
+    { url = "https://files.pythonhosted.org/packages/f8/aa/7af4e81f7acba21a4c6be026da38fd2b872ca46226673c89a758ebdc4fd2/PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774", size = 184612, upload-time = "2024-08-06T20:32:03.408Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/62/b9faa998fd185f65c1371643678e4d58254add437edb764a08c5a98fb986/PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee", size = 172040, upload-time = "2024-08-06T20:32:04.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/0c/c804f5f922a9a6563bab712d8dcc70251e8af811fce4524d57c2c0fd49a4/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c", size = 736829, upload-time = "2024-08-06T20:32:06.459Z" },
+    { url = "https://files.pythonhosted.org/packages/51/16/6af8d6a6b210c8e54f1406a6b9481febf9c64a3109c541567e35a49aa2e7/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317", size = 764167, upload-time = "2024-08-06T20:32:08.338Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e4/2c27590dfc9992f73aabbeb9241ae20220bd9452df27483b6e56d3975cc5/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85", size = 762952, upload-time = "2024-08-06T20:32:14.124Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/97/ecc1abf4a823f5ac61941a9c00fe501b02ac3ab0e373c3857f7d4b83e2b6/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4", size = 735301, upload-time = "2024-08-06T20:32:16.17Z" },
+    { url = "https://files.pythonhosted.org/packages/45/73/0f49dacd6e82c9430e46f4a027baa4ca205e8b0a9dce1397f44edc23559d/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e", size = 756638, upload-time = "2024-08-06T20:32:18.555Z" },
+    { url = "https://files.pythonhosted.org/packages/22/5f/956f0f9fc65223a58fbc14459bf34b4cc48dec52e00535c79b8db361aabd/PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5", size = 143850, upload-time = "2024-08-06T20:32:19.889Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/8da0bbe2ab9dcdd11f4f4557ccaf95c10b9811b13ecced089d43ce59c3c8/PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44", size = 161980, upload-time = "2024-08-06T20:32:21.273Z" },
+    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873, upload-time = "2024-08-06T20:32:25.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302, upload-time = "2024-08-06T20:32:26.511Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154, upload-time = "2024-08-06T20:32:28.363Z" },
+    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223, upload-time = "2024-08-06T20:32:30.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542, upload-time = "2024-08-06T20:32:31.881Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164, upload-time = "2024-08-06T20:32:37.083Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611, upload-time = "2024-08-06T20:32:38.898Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591, upload-time = "2024-08-06T20:32:40.241Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338, upload-time = "2024-08-06T20:32:41.93Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309, upload-time = "2024-08-06T20:32:43.4Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679, upload-time = "2024-08-06T20:32:44.801Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428, upload-time = "2024-08-06T20:32:46.432Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361, upload-time = "2024-08-06T20:32:51.188Z" },
+    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523, upload-time = "2024-08-06T20:32:53.019Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660, upload-time = "2024-08-06T20:32:54.708Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
+    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
 ]
 
 [[package]]
 name = "ruff"
 version = "0.9.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/02/74/6c359f6b9ed85b88df6ef31febce18faeb852f6c9855651dfb1184a46845/ruff-0.9.5.tar.gz", hash = "sha256:11aecd7a633932875ab3cb05a484c99970b9d52606ce9ea912b690b02653d56c", size = 3634177 }
+sdist = { url = "https://files.pythonhosted.org/packages/02/74/6c359f6b9ed85b88df6ef31febce18faeb852f6c9855651dfb1184a46845/ruff-0.9.5.tar.gz", hash = "sha256:11aecd7a633932875ab3cb05a484c99970b9d52606ce9ea912b690b02653d56c", size = 3634177, upload-time = "2025-02-06T19:47:15.41Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/4b/82b7c9ac874e72b82b19fd7eab57d122e2df44d2478d90825854f9232d02/ruff-0.9.5-py3-none-linux_armv6l.whl", hash = "sha256:d466d2abc05f39018d53f681fa1c0ffe9570e6d73cde1b65d23bb557c846f442", size = 11681264 },
-    { url = "https://files.pythonhosted.org/packages/27/5c/f5ae0a9564e04108c132e1139d60491c0abc621397fe79a50b3dc0bd704b/ruff-0.9.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:38840dbcef63948657fa7605ca363194d2fe8c26ce8f9ae12eee7f098c85ac8a", size = 11657554 },
-    { url = "https://files.pythonhosted.org/packages/2a/83/c6926fa3ccb97cdb3c438bb56a490b395770c750bf59f9bc1fe57ae88264/ruff-0.9.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d56ba06da53536b575fbd2b56517f6f95774ff7be0f62c80b9e67430391eeb36", size = 11088959 },
-    { url = "https://files.pythonhosted.org/packages/af/a7/42d1832b752fe969ffdbfcb1b4cb477cb271bed5835110fb0a16ef31ab81/ruff-0.9.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f7cb2a01da08244c50b20ccfaeb5972e4228c3c3a1989d3ece2bc4b1f996001", size = 11902041 },
-    { url = "https://files.pythonhosted.org/packages/53/cf/1fffa09fb518d646f560ccfba59f91b23c731e461d6a4dedd21a393a1ff1/ruff-0.9.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:96d5c76358419bc63a671caac70c18732d4fd0341646ecd01641ddda5c39ca0b", size = 11421069 },
-    { url = "https://files.pythonhosted.org/packages/09/27/bb8f1b7304e2a9431f631ae7eadc35550fe0cf620a2a6a0fc4aa3d736f94/ruff-0.9.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:deb8304636ed394211f3a6d46c0e7d9535b016f53adaa8340139859b2359a070", size = 12625095 },
-    { url = "https://files.pythonhosted.org/packages/d7/ce/ab00bc9d3df35a5f1b64f5117458160a009f93ae5caf65894ebb63a1842d/ruff-0.9.5-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:df455000bf59e62b3e8c7ba5ed88a4a2bc64896f900f311dc23ff2dc38156440", size = 13257797 },
-    { url = "https://files.pythonhosted.org/packages/88/81/c639a082ae6d8392bc52256058ec60f493c6a4d06d5505bccface3767e61/ruff-0.9.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de92170dfa50c32a2b8206a647949590e752aca8100a0f6b8cefa02ae29dce80", size = 12763793 },
-    { url = "https://files.pythonhosted.org/packages/b3/d0/0a3d8f56d1e49af466dc770eeec5c125977ba9479af92e484b5b0251ce9c/ruff-0.9.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3d28532d73b1f3f627ba88e1456f50748b37f3a345d2be76e4c653bec6c3e393", size = 14386234 },
-    { url = "https://files.pythonhosted.org/packages/04/70/e59c192a3ad476355e7f45fb3a87326f5219cc7c472e6b040c6c6595c8f0/ruff-0.9.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c746d7d1df64f31d90503ece5cc34d7007c06751a7a3bbeee10e5f2463d52d2", size = 12437505 },
-    { url = "https://files.pythonhosted.org/packages/55/4e/3abba60a259d79c391713e7a6ccabf7e2c96e5e0a19100bc4204f1a43a51/ruff-0.9.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:11417521d6f2d121fda376f0d2169fb529976c544d653d1d6044f4c5562516ee", size = 11884799 },
-    { url = "https://files.pythonhosted.org/packages/a3/db/b0183a01a9f25b4efcae919c18fb41d32f985676c917008620ad692b9d5f/ruff-0.9.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5b9d71c3879eb32de700f2f6fac3d46566f644a91d3130119a6378f9312a38e1", size = 11527411 },
-    { url = "https://files.pythonhosted.org/packages/0a/e4/3ebfcebca3dff1559a74c6becff76e0b64689cea02b7aab15b8b32ea245d/ruff-0.9.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2e36c61145e70febcb78483903c43444c6b9d40f6d2f800b5552fec6e4a7bb9a", size = 12078868 },
-    { url = "https://files.pythonhosted.org/packages/ec/b2/5ab808833e06c0a1b0d046a51c06ec5687b73c78b116e8d77687dc0cd515/ruff-0.9.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2f71d09aeba026c922aa7aa19a08d7bd27c867aedb2f74285a2639644c1c12f5", size = 12524374 },
-    { url = "https://files.pythonhosted.org/packages/e0/51/1432afcc3b7aa6586c480142caae5323d59750925c3559688f2a9867343f/ruff-0.9.5-py3-none-win32.whl", hash = "sha256:134f958d52aa6fdec3b294b8ebe2320a950d10c041473c4316d2e7d7c2544723", size = 9853682 },
-    { url = "https://files.pythonhosted.org/packages/b7/ad/c7a900591bd152bb47fc4882a27654ea55c7973e6d5d6396298ad3fd6638/ruff-0.9.5-py3-none-win_amd64.whl", hash = "sha256:78cc6067f6d80b6745b67498fb84e87d32c6fc34992b52bffefbdae3442967d6", size = 10865744 },
-    { url = "https://files.pythonhosted.org/packages/75/d9/fde7610abd53c0c76b6af72fc679cb377b27c617ba704e25da834e0a0608/ruff-0.9.5-py3-none-win_arm64.whl", hash = "sha256:18a29f1a005bddb229e580795627d297dfa99f16b30c7039e73278cf6b5f9fa9", size = 10064595 },
+    { url = "https://files.pythonhosted.org/packages/17/4b/82b7c9ac874e72b82b19fd7eab57d122e2df44d2478d90825854f9232d02/ruff-0.9.5-py3-none-linux_armv6l.whl", hash = "sha256:d466d2abc05f39018d53f681fa1c0ffe9570e6d73cde1b65d23bb557c846f442", size = 11681264, upload-time = "2025-02-06T19:46:16.452Z" },
+    { url = "https://files.pythonhosted.org/packages/27/5c/f5ae0a9564e04108c132e1139d60491c0abc621397fe79a50b3dc0bd704b/ruff-0.9.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:38840dbcef63948657fa7605ca363194d2fe8c26ce8f9ae12eee7f098c85ac8a", size = 11657554, upload-time = "2025-02-06T19:46:21.854Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/83/c6926fa3ccb97cdb3c438bb56a490b395770c750bf59f9bc1fe57ae88264/ruff-0.9.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d56ba06da53536b575fbd2b56517f6f95774ff7be0f62c80b9e67430391eeb36", size = 11088959, upload-time = "2025-02-06T19:46:25.109Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a7/42d1832b752fe969ffdbfcb1b4cb477cb271bed5835110fb0a16ef31ab81/ruff-0.9.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f7cb2a01da08244c50b20ccfaeb5972e4228c3c3a1989d3ece2bc4b1f996001", size = 11902041, upload-time = "2025-02-06T19:46:29.288Z" },
+    { url = "https://files.pythonhosted.org/packages/53/cf/1fffa09fb518d646f560ccfba59f91b23c731e461d6a4dedd21a393a1ff1/ruff-0.9.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:96d5c76358419bc63a671caac70c18732d4fd0341646ecd01641ddda5c39ca0b", size = 11421069, upload-time = "2025-02-06T19:46:32.947Z" },
+    { url = "https://files.pythonhosted.org/packages/09/27/bb8f1b7304e2a9431f631ae7eadc35550fe0cf620a2a6a0fc4aa3d736f94/ruff-0.9.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:deb8304636ed394211f3a6d46c0e7d9535b016f53adaa8340139859b2359a070", size = 12625095, upload-time = "2025-02-06T19:46:36.015Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/ab00bc9d3df35a5f1b64f5117458160a009f93ae5caf65894ebb63a1842d/ruff-0.9.5-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:df455000bf59e62b3e8c7ba5ed88a4a2bc64896f900f311dc23ff2dc38156440", size = 13257797, upload-time = "2025-02-06T19:46:39.556Z" },
+    { url = "https://files.pythonhosted.org/packages/88/81/c639a082ae6d8392bc52256058ec60f493c6a4d06d5505bccface3767e61/ruff-0.9.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de92170dfa50c32a2b8206a647949590e752aca8100a0f6b8cefa02ae29dce80", size = 12763793, upload-time = "2025-02-06T19:46:43.294Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/d0/0a3d8f56d1e49af466dc770eeec5c125977ba9479af92e484b5b0251ce9c/ruff-0.9.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3d28532d73b1f3f627ba88e1456f50748b37f3a345d2be76e4c653bec6c3e393", size = 14386234, upload-time = "2025-02-06T19:46:47.062Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e59c192a3ad476355e7f45fb3a87326f5219cc7c472e6b040c6c6595c8f0/ruff-0.9.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c746d7d1df64f31d90503ece5cc34d7007c06751a7a3bbeee10e5f2463d52d2", size = 12437505, upload-time = "2025-02-06T19:46:49.986Z" },
+    { url = "https://files.pythonhosted.org/packages/55/4e/3abba60a259d79c391713e7a6ccabf7e2c96e5e0a19100bc4204f1a43a51/ruff-0.9.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:11417521d6f2d121fda376f0d2169fb529976c544d653d1d6044f4c5562516ee", size = 11884799, upload-time = "2025-02-06T19:46:53.593Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/db/b0183a01a9f25b4efcae919c18fb41d32f985676c917008620ad692b9d5f/ruff-0.9.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5b9d71c3879eb32de700f2f6fac3d46566f644a91d3130119a6378f9312a38e1", size = 11527411, upload-time = "2025-02-06T19:46:56.531Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/e4/3ebfcebca3dff1559a74c6becff76e0b64689cea02b7aab15b8b32ea245d/ruff-0.9.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2e36c61145e70febcb78483903c43444c6b9d40f6d2f800b5552fec6e4a7bb9a", size = 12078868, upload-time = "2025-02-06T19:46:59.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b2/5ab808833e06c0a1b0d046a51c06ec5687b73c78b116e8d77687dc0cd515/ruff-0.9.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2f71d09aeba026c922aa7aa19a08d7bd27c867aedb2f74285a2639644c1c12f5", size = 12524374, upload-time = "2025-02-06T19:47:02.897Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/51/1432afcc3b7aa6586c480142caae5323d59750925c3559688f2a9867343f/ruff-0.9.5-py3-none-win32.whl", hash = "sha256:134f958d52aa6fdec3b294b8ebe2320a950d10c041473c4316d2e7d7c2544723", size = 9853682, upload-time = "2025-02-06T19:47:05.576Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/ad/c7a900591bd152bb47fc4882a27654ea55c7973e6d5d6396298ad3fd6638/ruff-0.9.5-py3-none-win_amd64.whl", hash = "sha256:78cc6067f6d80b6745b67498fb84e87d32c6fc34992b52bffefbdae3442967d6", size = 10865744, upload-time = "2025-02-06T19:47:09.205Z" },
+    { url = "https://files.pythonhosted.org/packages/75/d9/fde7610abd53c0c76b6af72fc679cb377b27c617ba704e25da834e0a0608/ruff-0.9.5-py3-none-win_arm64.whl", hash = "sha256:18a29f1a005bddb229e580795627d297dfa99f16b30c7039e73278cf6b5f9fa9", size = 10064595, upload-time = "2025-02-06T19:47:12.071Z" },
 ]
 
 [[package]]
@@ -212,7 +213,7 @@ dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/ca/f23dcb02e161a9bba141b1c08aa50e8da6ea25e6d780528f1d385a3efe25/virtualenv-20.29.1.tar.gz", hash = "sha256:b8b8970138d32fb606192cb97f6cd4bb644fa486be9308fb9b63f81091b5dc35", size = 7658028 }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/ca/f23dcb02e161a9bba141b1c08aa50e8da6ea25e6d780528f1d385a3efe25/virtualenv-20.29.1.tar.gz", hash = "sha256:b8b8970138d32fb606192cb97f6cd4bb644fa486be9308fb9b63f81091b5dc35", size = 7658028, upload-time = "2025-01-17T17:32:23.085Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/9b/599bcfc7064fbe5740919e78c5df18e5dceb0887e676256a1061bb5ae232/virtualenv-20.29.1-py3-none-any.whl", hash = "sha256:4e4cb403c0b0da39e13b46b1b2476e505cb0046b25f242bee80f62bf990b2779", size = 4282379 },
+    { url = "https://files.pythonhosted.org/packages/89/9b/599bcfc7064fbe5740919e78c5df18e5dceb0887e676256a1061bb5ae232/virtualenv-20.29.1-py3-none-any.whl", hash = "sha256:4e4cb403c0b0da39e13b46b1b2476e505cb0046b25f242bee80f62bf990b2779", size = 4282379, upload-time = "2025-01-17T17:32:19.864Z" },
 ]


### PR DESCRIPTION
## Summary
- `Query` and `Table` are now concrete classes accepting a `dialect: str` argument instead of relying on dialect-specific subclasses
- Removes `MySQLQuery`, `PostgreSQLQuery`, `OracleQuery`, `SQLiteQuery`, `QueryRegistry`, and `Table.create()` factory — along with the `MySQLTable`/`PostgresTable`/`OracleTable`/`SqliteTable` module-level aliases
- All call sites (`Schema`, `ddl_loader`, tests) updated to use `Query("mysql")` / `Table("name", dialect="mysql")` style

## Test plan
- [ ] All 127 existing tests pass (`uv run pytest`)
- [ ] Verify `Query("non-existent-dialect")` raises `ValueError`
- [ ] Verify `Table("name", dialect="non-existent-dialect")` raises `ValueError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)