### PR TITLE
Add IS NULL / IS NOT NULL and boolean composition on Expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,28 @@ Output:
 SELECT "first_name" AS name FROM "employee" AS e
 ```
 
+## NULL Checks and Boolean Composition
+Columns support `is_null()` / `is_not_null()`, and `Expression`s can be combined with `&` (AND), `|` (OR), and `~` (NOT). Child expressions are parenthesized so precedence is explicit:
+
+```python
+from pysqlscribe.table import Table
+
+table = Table("employees", "salary", "bonus", "department_id", dialect="postgres")
+query = (
+    table.select()
+    .where((table.salary > 1000) | table.bonus.is_null())
+    .build()
+)
+```
+
+Output:
+
+```postgresql
+SELECT * FROM "employees" WHERE (employees.salary > 1000) OR (employees.bonus IS NULL)
+```
+
+Note: Python's `&` / `|` / `~` have higher precedence than comparison operators, so wrap each comparison in parentheses: `(col == 1) | (col == 2)`.
+
 ## Subqueries
 Subqueries can be used when evaluating `Column`s in the form of a membership:
 

--- a/README.md
+++ b/README.md
@@ -322,8 +322,24 @@ Output:
 SELECT "first_name" AS name FROM "employee" AS e
 ```
 
-## NULL Checks and Boolean Composition
-Columns support `is_null()` / `is_not_null()`, and `Expression`s can be combined with `&` (AND), `|` (OR), and `~` (NOT). Child expressions are parenthesized so precedence is explicit:
+## NULL Checks
+Columns support `is_null()` and `is_not_null()` for NULL comparisons:
+
+```python
+from pysqlscribe.table import Table
+
+table = Table("employees", "salary", "bonus", dialect="postgres")
+query = table.select("salary").where(table.bonus.is_null()).build()
+```
+
+Output:
+
+```postgresql
+SELECT "salary" FROM "employees" WHERE employees.bonus IS NULL
+```
+
+## Boolean Composition
+`Expression`s can be combined with `&` (AND), `|` (OR), and `~` (NOT). Child expressions are parenthesized so precedence is explicit:
 
 ```python
 from pysqlscribe.table import Table

--- a/pysqlscribe/column.py
+++ b/pysqlscribe/column.py
@@ -22,6 +22,42 @@ class Expression:
     def __repr__(self):
         return f"Expression({self.left!r}, {self.operator!r}, {self.right!r})"
 
+    def __and__(self, other: "Expression") -> "CompoundExpression":
+        return CompoundExpression(self, "AND", other)
+
+    def __or__(self, other: "Expression") -> "CompoundExpression":
+        return CompoundExpression(self, "OR", other)
+
+    def __invert__(self) -> "NotExpression":
+        return NotExpression(self)
+
+
+class CompoundExpression(Expression):
+    def __init__(self, left: Expression, operator: str, right: Expression):
+        self.left = left
+        self.operator = operator
+        self.right = right
+
+    def __str__(self):
+        return f"({self.left}) {self.operator} ({self.right})"
+
+    def __repr__(self):
+        return f"CompoundExpression({self.left!r}, {self.operator!r}, {self.right!r})"
+
+
+class NotExpression(Expression):
+    def __init__(self, inner: Expression):
+        self.inner = inner
+        self.left = "NOT"
+        self.operator = ""
+        self.right = inner
+
+    def __str__(self):
+        return f"NOT ({self.inner})"
+
+    def __repr__(self):
+        return f"NotExpression({self.inner!r})"
+
 
 class OrderedColumn:
     """A column paired with a sort direction, produced by Column.asc() or Column.desc()."""
@@ -174,6 +210,12 @@ class Column(AliasMixin):
 
     def not_between(self, low, high) -> Expression:
         return self._between(low, high, "NOT BETWEEN")
+
+    def is_null(self) -> Expression:
+        return Expression(self.fully_qualified_name, "IS", "NULL")
+
+    def is_not_null(self) -> Expression:
+        return Expression(self.fully_qualified_name, "IS NOT", "NULL")
 
     def _sort(self, direction: str) -> OrderedColumn:
         return OrderedColumn(self.name, direction)

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -1,8 +1,10 @@
 from pysqlscribe.column import (
     Column,
+    CompoundExpression,
     Expression,
     InvalidColumnNameException,
     ExpressionColumn,
+    NotExpression,
 )
 import pytest
 
@@ -113,6 +115,57 @@ def test_combined_column_fqn():
     col2 = Column("column2", "table2")
     combined = col1 + col2
     assert combined.fully_qualified_name == "table1.column1 + table2.column2"
+
+
+def test_column_is_null():
+    col = Column("column1", "table1")
+    expr = col.is_null()
+    assert isinstance(expr, Expression)
+    assert str(expr) == "table1.column1 IS NULL"
+
+
+def test_column_is_not_null():
+    col = Column("column1", "table1")
+    expr = col.is_not_null()
+    assert isinstance(expr, Expression)
+    assert str(expr) == "table1.column1 IS NOT NULL"
+
+
+def test_expression_and():
+    col = Column("column1", "table1")
+    expr = (col == 1) & (col > 5)
+    assert isinstance(expr, CompoundExpression)
+    assert str(expr) == "(table1.column1 = 1) AND (table1.column1 > 5)"
+
+
+def test_expression_or():
+    col = Column("column1", "table1")
+    expr = (col == 1) | (col == 2)
+    assert isinstance(expr, CompoundExpression)
+    assert str(expr) == "(table1.column1 = 1) OR (table1.column1 = 2)"
+
+
+def test_expression_not():
+    col = Column("column1", "table1")
+    expr = ~col.is_null()
+    assert isinstance(expr, NotExpression)
+    assert str(expr) == "NOT (table1.column1 IS NULL)"
+
+
+def test_expression_mixed_precedence():
+    col = Column("column1", "table1")
+    other = Column("column2", "table1")
+    expr = (col == 1) & ((other > 5) | other.is_null())
+    assert (
+        str(expr)
+        == "(table1.column1 = 1) AND ((table1.column2 > 5) OR (table1.column2 IS NULL))"
+    )
+
+
+def test_expression_not_compound():
+    col = Column("column1", "table1")
+    expr = ~((col == 1) | (col == 2))
+    assert str(expr) == "NOT ((table1.column1 = 1) OR (table1.column1 = 2))"
 
 
 def test_column_not_implemented():

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -66,6 +66,37 @@ def test_table_where_clause_other_column():
     )
 
 
+def test_table_where_is_null():
+    table = Table("test_table", "test_column", dialect="mysql")
+    query = table.select("test_column").where(table.test_column.is_null()).build()
+    assert (
+        query
+        == "SELECT `test_column` FROM `test_table` WHERE test_table.test_column IS NULL"
+    )
+
+
+def test_table_where_or_composition():
+    table = Table("test_table", "test_column", dialect="mysql")
+    query = (
+        table.select("test_column")
+        .where((table.test_column == 1) | (table.test_column == 2))
+        .build()
+    )
+    assert (
+        query == "SELECT `test_column` FROM `test_table` "
+        "WHERE (test_table.test_column = 1) OR (test_table.test_column = 2)"
+    )
+
+
+def test_table_where_not_is_null():
+    table = Table("test_table", "test_column", dialect="mysql")
+    query = table.select("test_column").where(~table.test_column.is_null()).build()
+    assert (
+        query
+        == "SELECT `test_column` FROM `test_table` WHERE NOT (test_table.test_column IS NULL)"
+    )
+
+
 def test_table_select_all():
     table = Table(
         "employee", "first_name", "last_name", "dept", "salary", dialect="postgres"


### PR DESCRIPTION
## Summary
- Adds `Column.is_null()` and `Column.is_not_null()` producing `Expression`s that render as `col IS NULL` / `col IS NOT NULL`.
- Adds `&` / `|` / `~` operators on `Expression` for AND / OR / NOT composition. Child expressions are parenthesized so precedence is explicit (`(a = 1) OR (a = 2)`).
- `WHERE` clauses no longer need to fall back to raw strings for null checks or OR logic — closes part of the "enhance how where clauses are handled" TODO.

## Example
```python
table.select().where((table.salary > 1000) | table.bonus.is_null()).build()
# SELECT * FROM "employees" WHERE (employees.salary > 1000) OR (employees.bonus IS NULL)
```

Note: Python's `&` / `|` / `~` bind tighter than comparisons, so comparisons need parentheses: `(col == 1) | (col == 2)`.

## Test plan
- [x] `is_null()` / `is_not_null()` on `Column` (unit)
- [x] `&`, `|`, `~` on `Expression` (unit)
- [x] Mixed precedence / nested composition (unit)
- [x] `Table.where(...)` integration for IS NULL, OR composition, and `~is_null()`
- [x] Full suite: `uv run pytest` — 142 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)