### PR TITLE
Add CASE WHEN expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,36 @@ SELECT * FROM "employees" WHERE (employees.salary > 1000) OR (employees.bonus IS
 
 Note: Python's `&` / `|` / `~` have higher precedence than comparison operators, so wrap each comparison in parentheses: `(col == 1) | (col == 2)`.
 
+## CASE Expressions
+`case_()` builds `CASE WHEN ... THEN ... [ELSE ...] END` expressions. Chain `.when(condition, value)` for each branch, `.else_(value)` for the default, and `.as_(alias)` for an alias. Values can be columns, strings (auto-quoted), or numbers.
+
+```python
+from pysqlscribe.column import case_
+from pysqlscribe.table import Table
+
+table = Table("employees", "dept", "salary", dialect="postgres")
+band = (
+    case_()
+    .when(table.salary > 100000, 1)
+    .when(table.salary > 50000, 2)
+    .else_(3)
+    .as_("salary_band")
+)
+query = table.select(table.dept, band).build()
+```
+
+Output:
+
+```postgresql
+SELECT "dept", CASE WHEN employees.salary > 100000 THEN 1 WHEN employees.salary > 50000 THEN 2 ELSE 3 END AS salary_band FROM "employees"
+```
+
+CASE expressions can also be used in `ORDER BY` and `GROUP BY`:
+
+```python
+table.select("dept").order_by(case_().when(table.dept == "Sales", 1).else_(2)).build()
+```
+
 ## Subqueries
 Subqueries can be used when evaluating `Column`s in the form of a membership:
 

--- a/pysqlscribe/column.py
+++ b/pysqlscribe/column.py
@@ -10,6 +10,22 @@ from pysqlscribe.regex_patterns import (
 )
 
 
+def _resolve_value(value) -> str:
+    """Render a CASE/comparison value: columns become fqn, strings are quoted,
+    numbers pass through, and pre-rendered expressions stringify as-is."""
+    if isinstance(value, Column):
+        return value.fully_qualified_name
+    if isinstance(value, Expression):
+        return str(value)
+    if isinstance(value, str):
+        return f"'{value}'"
+    if isinstance(value, (int, float)):
+        return str(value)
+    raise NotImplementedError(
+        f"Unsupported value type for SQL expression: {type(value).__name__}"
+    )
+
+
 class Expression:
     def __init__(self, left: str, operator: str, right: str):
         self.left = left
@@ -234,3 +250,37 @@ class ExpressionColumn(Column):
     @property
     def fully_qualified_name(self):
         return self.name
+
+
+_UNSET = object()
+
+
+class Case(AliasMixin):
+    """Builder for CASE WHEN ... THEN ... [ELSE ...] END expressions."""
+
+    def __init__(self):
+        self._whens: list[tuple[Expression, object]] = []
+        self._else = _UNSET
+
+    def when(self, condition: Expression, value) -> Self:
+        self._whens.append((condition, value))
+        return self
+
+    def else_(self, value) -> Self:
+        self._else = value
+        return self
+
+    def __str__(self) -> str:
+        if not self._whens:
+            raise ValueError("CASE requires at least one WHEN clause")
+        parts = ["CASE"]
+        for cond, val in self._whens:
+            parts.append(f"WHEN {cond} THEN {_resolve_value(val)}")
+        if self._else is not _UNSET:
+            parts.append(f"ELSE {_resolve_value(self._else)}")
+        parts.append("END")
+        return " ".join(parts) + self.alias
+
+
+def case_() -> Case:
+    return Case()

--- a/pysqlscribe/dialects/base.py
+++ b/pysqlscribe/dialects/base.py
@@ -27,6 +27,7 @@ from pysqlscribe.regex_patterns import (
     AGGREGATE_IDENTIFIER_REGEX,
     SCALAR_IDENTIFIER_REGEX,
     EXPRESSION_IDENTIFIER_REGEX,
+    CASE_IDENTIFIER_REGEX,
     ALIAS_REGEX,
 )
 from pysqlscribe.renderers.base import Renderer
@@ -112,6 +113,7 @@ class Dialect(ABC):
             AGGREGATE_IDENTIFIER_REGEX.match(identifier)
             or SCALAR_IDENTIFIER_REGEX.match(identifier)
             or EXPRESSION_IDENTIFIER_REGEX.match(identifier)
+            or CASE_IDENTIFIER_REGEX.match(identifier)
         ):
             identifier = identifier
         else:

--- a/pysqlscribe/regex_patterns.py
+++ b/pysqlscribe/regex_patterns.py
@@ -40,6 +40,12 @@ EXPRESSION_IDENTIFIER_REGEX = re.compile(
     rf"^\s*{TERM_REGEX}(?:\s*[\+\-\*/]\s*{TERM_REGEX})*\s*$"
 )
 
+# CASE expressions are produced by the builder so their internals are trusted;
+# this check only confirms the outer shape.
+CASE_IDENTIFIER_REGEX = re.compile(
+    r"^\s*CASE\s+WHEN\b.+\bEND\s*$", re.IGNORECASE | re.DOTALL
+)
+
 CONSTRAINT_PREFIX_REGEX = r"^(PRIMARY|FOREIGN|CONSTRAINT|UNIQUE|INDEX)"
 
 ALIAS_REGEX = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")

--- a/pysqlscribe/renderers/base.py
+++ b/pysqlscribe/renderers/base.py
@@ -150,7 +150,7 @@ class Renderer:
     def _resolve_columns(self, *args) -> str:
         if not args:
             args = ["*"]
-        if WILDCARD_REGEX.match(args[0]):
+        if isinstance(args[0], str) and WILDCARD_REGEX.match(args[0]):
             columns = args[0]
         else:
             columns = self.dialect.normalize_identifiers_args(args)

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -1,10 +1,12 @@
 from pysqlscribe.column import (
+    Case,
     Column,
     CompoundExpression,
     Expression,
     InvalidColumnNameException,
     ExpressionColumn,
     NotExpression,
+    case_,
 )
 import pytest
 
@@ -166,6 +168,59 @@ def test_expression_not_compound():
     col = Column("column1", "table1")
     expr = ~((col == 1) | (col == 2))
     assert str(expr) == "NOT ((table1.column1 = 1) OR (table1.column1 = 2))"
+
+
+def test_case_basic_with_else():
+    col = Column("dept", "employees")
+    expr = case_().when(col == "Sales", "sales").else_("other")
+    assert isinstance(expr, Case)
+    assert (
+        str(expr) == "CASE WHEN employees.dept = 'Sales' THEN 'sales' ELSE 'other' END"
+    )
+
+
+def test_case_without_else():
+    col = Column("dept", "employees")
+    expr = case_().when(col == "Sales", "sales")
+    assert str(expr) == "CASE WHEN employees.dept = 'Sales' THEN 'sales' END"
+
+
+def test_case_multiple_whens_numeric():
+    col = Column("salary", "employees")
+    expr = case_().when(col > 100000, 1).when(col > 50000, 2).else_(3)
+    assert (
+        str(expr)
+        == "CASE WHEN employees.salary > 100000 THEN 1 WHEN employees.salary > 50000 THEN 2 ELSE 3 END"
+    )
+
+
+def test_case_column_valued_then():
+    dept = Column("dept", "employees")
+    salary = Column("salary", "employees")
+    expr = case_().when(dept == "Sales", salary).else_(0)
+    assert (
+        str(expr)
+        == "CASE WHEN employees.dept = 'Sales' THEN employees.salary ELSE 0 END"
+    )
+
+
+def test_case_with_alias():
+    col = Column("dept", "employees")
+    expr = case_().when(col == "Sales", 1).else_(0).as_("is_sales")
+    assert (
+        str(expr) == "CASE WHEN employees.dept = 'Sales' THEN 1 ELSE 0 END AS is_sales"
+    )
+
+
+def test_case_empty_raises():
+    with pytest.raises(ValueError):
+        str(case_())
+
+
+def test_case_unsupported_value_type():
+    col = Column("dept", "employees")
+    with pytest.raises(NotImplementedError):
+        str(case_().when(col == "Sales", ["list"]))
 
 
 def test_column_not_implemented():

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,7 +1,8 @@
 import pytest
 
-from pysqlscribe.aggregate_functions import avg
+from pysqlscribe.aggregate_functions import avg, count
 from pysqlscribe.ast.joins import JoinType
+from pysqlscribe.column import case_
 
 from pysqlscribe.table import Table
 
@@ -85,6 +86,43 @@ def test_table_where_or_composition():
     assert (
         query == "SELECT `test_column` FROM `test_table` "
         "WHERE (test_table.test_column = 1) OR (test_table.test_column = 2)"
+    )
+
+
+def test_table_case_in_select():
+    table = Table("employees", "dept", "salary", dialect="postgres")
+    expr = (
+        case_()
+        .when(table.dept == "Sales", "sales_team")
+        .else_("other")
+        .as_("team_label")
+    )
+    query = table.select(expr).build()
+    assert (
+        query
+        == "SELECT CASE WHEN employees.dept = 'Sales' THEN 'sales_team' ELSE 'other' END AS team_label FROM \"employees\""
+    )
+
+
+def test_table_case_in_order_by():
+    table = Table("employees", "dept", "salary", dialect="postgres")
+    expr = case_().when(table.dept == "Sales", 1).else_(2)
+    query = table.select("dept").order_by(expr).build()
+    assert (
+        query
+        == 'SELECT "dept" FROM "employees" ORDER BY CASE WHEN employees.dept = \'Sales\' THEN 1 ELSE 2 END'
+    )
+
+
+def test_table_case_in_group_by():
+    table = Table("employees", "salary", dialect="postgres")
+    band = case_().when(table.salary > 50000, "high").else_("low")
+    query = table.select(band, count("*")).group_by(band).build()
+    assert (
+        query
+        == "SELECT CASE WHEN employees.salary > 50000 THEN 'high' ELSE 'low' END, "
+        'COUNT(*) FROM "employees" '
+        "GROUP BY CASE WHEN employees.salary > 50000 THEN 'high' ELSE 'low' END"
     )
 
 


### PR DESCRIPTION
## Summary
- Adds `case_()` builder producing `CASE WHEN ... THEN ... [ELSE ...] END` expressions, usable in `select()`, `order_by()`, and `group_by()`. Supports column/string/number values, optional `ELSE`, and `.as_(alias)`.
- Wires CASE into `Dialect.validate_identifier` via a new `CASE_IDENTIFIER_REGEX` so CASE strings survive the identifier whitelist in the SELECT/ORDER BY/GROUP BY paths.
- Fixes `Renderer._resolve_columns` to tolerate non-string column expressions when checking the wildcard (`WILDCARD_REGEX.match` previously blew up on objects).

## Example
```python
from pysqlscribe.column import case_
from pysqlscribe.table import Table

table = Table("employees", "dept", "salary", dialect="postgres")
band = (
    case_()
    .when(table.salary > 100000, 1)
    .when(table.salary > 50000, 2)
    .else_(3)
    .as_("salary_band")
)
table.select(table.dept, band).build()
# SELECT "dept", CASE WHEN employees.salary > 100000 THEN 1 WHEN employees.salary > 50000 THEN 2 ELSE 3 END AS salary_band FROM "employees"
```

## Known limitation
`ALIAS_SPLIT_REGEX` splits on the first `\s+AS\s+` with `maxsplit=1`, which could mis-split a CASE whose value contains `" AS "` inside a string literal. Not fixed here; flag a separate issue if it ever bites.

## Test plan
- [x] Unit tests for `Case`: basic, no ELSE, multiple WHENs, column-valued THEN, alias, empty-raises, unsupported-value-raises
- [x] Integration tests: CASE in `select()`, `order_by()`, `group_by()`
- [x] Full suite: `uv run pytest` — 152 passed (was 142)

🤖 Generated with [Claude Code](https://claude.com/claude-code)