### PR TITLE
Support Overrides

### DIFF
--- a/pysqlscribe/column.py
+++ b/pysqlscribe/column.py
@@ -179,8 +179,8 @@ class Column(AliasMixin):
     def __round__(self, ndigits: int | None = None):
         round_expr = (
             f"{ScalarFunctions.ROUND}({self.name}, {ndigits})"
-            if ndigits
-            else f"ROUND({self.name})"
+            if ndigits is not None
+            else f"{ScalarFunctions.ROUND}({self.name})"
         )
         return ExpressionColumn(round_expr, self.table_name)
 

--- a/pysqlscribe/column.py
+++ b/pysqlscribe/column.py
@@ -2,6 +2,7 @@ from typing import Self, Iterable, Protocol, runtime_checkable
 
 from pysqlscribe.alias import AliasMixin
 from pysqlscribe.exceptions import InvalidColumnNameException
+from pysqlscribe.functions import ScalarFunctions
 from pysqlscribe.regex_patterns import (
     VALID_IDENTIFIER_REGEX,
     AGGREGATE_IDENTIFIER_REGEX,
@@ -177,18 +178,22 @@ class Column(AliasMixin):
 
     def __round__(self, ndigits: int | None = None):
         round_expr = (
-            f"ROUND({self.name}, {ndigits})" if ndigits else f"ROUND({self.name})"
+            f"{ScalarFunctions.ROUND}({self.name}, {ndigits})"
+            if ndigits
+            else f"ROUND({self.name})"
         )
         return ExpressionColumn(round_expr, self.table_name)
 
     def __abs__(self):
-        return ExpressionColumn(f"ABS({self.name})", self.table_name)
+        return ExpressionColumn(f"{ScalarFunctions.ABS}({self.name})", self.table_name)
 
     def __floor__(self):
-        return ExpressionColumn(f"FLOOR({self.name})", self.table_name)
+        return ExpressionColumn(
+            f"{ScalarFunctions.FLOOR}({self.name})", self.table_name
+        )
 
     def __ceil__(self):
-        return ExpressionColumn(f"CEIL({self.name})", self.table_name)
+        return ExpressionColumn(f"{ScalarFunctions.CEIL}({self.name})", self.table_name)
 
     def in_(self, values: Iterable[str | int | float] | Subqueryish) -> Expression:
         return self._membership_expression("IN", values)

--- a/pysqlscribe/column.py
+++ b/pysqlscribe/column.py
@@ -175,6 +175,21 @@ class Column(AliasMixin):
     def __truediv__(self, other):
         return self._arithmetic_expression("/", other)
 
+    def __round__(self, ndigits: int | None = None):
+        round_expr = (
+            f"ROUND({self.name}, {ndigits})" if ndigits else f"ROUND({self.name})"
+        )
+        return ExpressionColumn(round_expr, self.table_name)
+
+    def __abs__(self):
+        return ExpressionColumn(f"ABS({self.name})", self.table_name)
+
+    def __floor__(self):
+        return ExpressionColumn(f"FLOOR({self.name})", self.table_name)
+
+    def __ceil__(self):
+        return ExpressionColumn(f"CEIL({self.name})", self.table_name)
+
     def in_(self, values: Iterable[str | int | float] | Subqueryish) -> Expression:
         return self._membership_expression("IN", values)
 

--- a/pysqlscribe/functions.py
+++ b/pysqlscribe/functions.py
@@ -16,7 +16,7 @@ class AggregateFunctions(str, Enum):
 class ScalarFunctions(str, Enum):
     ABS = "ABS"
     FLOOR = "FLOOR"
-    CEIL = "CEIl"
+    CEIL = "CEIL"
     SQRT = "SQRT"
     ROUND = "ROUND"
     SIGN = "SIGN"

--- a/pysqlscribe/scalar_functions.py
+++ b/pysqlscribe/scalar_functions.py
@@ -1,3 +1,5 @@
+import math
+
 from pysqlscribe.column import Column, ExpressionColumn
 from pysqlscribe.functions import ScalarFunctions
 
@@ -9,14 +11,20 @@ def _scalar_function(scalar_function: str, column: Column | str | int) -> Column
 
 
 def abs_(column: Column | str):
+    if isinstance(column, Column):
+        return abs(column)
     return _scalar_function(ScalarFunctions.ABS, column)
 
 
 def floor(column: Column | str):
+    if isinstance(column, Column):
+        return math.floor(column)
     return _scalar_function(ScalarFunctions.FLOOR, column)
 
 
 def ceil(column: Column | str):
+    if isinstance(column, Column):
+        return math.ceil(column)
     return _scalar_function(ScalarFunctions.CEIL, column)
 
 
@@ -61,9 +69,7 @@ def round_(column: Column | str, decimals: int | None = None):
         return _scalar_function(ScalarFunctions.ROUND, column)
     if not isinstance(column, Column):
         return f"{ScalarFunctions.ROUND}({column}, {decimals})"
-    return ExpressionColumn(
-        f"{ScalarFunctions.ROUND}({column}, {decimals})", column.table_name
-    )
+    return round(column, decimals)
 
 
 def trunc(column: Column | str, decimals: int | None = None):

--- a/pysqlscribe/scalar_functions.py
+++ b/pysqlscribe/scalar_functions.py
@@ -65,7 +65,7 @@ def reverse(column: Column | str):
 
 
 def round_(column: Column | str, decimals: int | None = None):
-    if not decimals:
+    if decimals is None:
         return _scalar_function(ScalarFunctions.ROUND, column)
     if not isinstance(column, Column):
         return f"{ScalarFunctions.ROUND}({column}, {decimals})"

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -147,7 +147,11 @@ def test_power_with_non_column(base, exponent):
 
 @pytest.mark.parametrize(
     "rounding_function_name,rounding_function",
-    [(ScalarFunctions.ROUND, round_), (ScalarFunctions.TRUNC, trunc)],
+    [
+        (ScalarFunctions.ROUND, round_),
+        (ScalarFunctions.ROUND, round),
+        (ScalarFunctions.TRUNC, trunc),
+    ],
 )
 def test_rounding_functions(rounding_function_name, rounding_function):
     payroll_table = Table("payroll", "id", "salary", "category", dialect="postgres")
@@ -156,9 +160,10 @@ def test_rounding_functions(rounding_function_name, rounding_function):
 
     query = payroll_table.select(rounding_function(payroll_table.salary, 2)).build()
     assert query == f'SELECT {rounding_function_name}(salary, 2) FROM "payroll"'
-
-    query = payroll_table.select(rounding_function(100.5678, 2)).build()
-    assert query == f'SELECT {rounding_function_name}(100.5678, 2) FROM "payroll"'
+    if rounding_function != round:
+        # deliberately skip this one for builtin `round` as it will return a float
+        query = payroll_table.select(rounding_function(100.5678, 2)).build()
+        assert query == f'SELECT {rounding_function_name}(100.5678, 2) FROM "payroll"'
 
 
 def test_nullif():

--- a/uv.lock
+++ b/uv.lock
@@ -110,7 +110,7 @@ wheels = [
 
 [[package]]
 name = "pysqlscribe"
-version = "0.11.1"
+version = "0.12.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Support using builtins `abs`, `floor`, `ceil`, and `round` as additional options for the corresponding operations in SQL dialects, rather than requiring the scalar function definitions.
