### PR TITLE
Add SELECT DISTINCT support

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,22 @@ Output:
 SELECT "first_name" AS name FROM "employee" AS e
 ```
 
+## DISTINCT
+Pass `distinct=True` to `select` to emit `SELECT DISTINCT`:
+
+```python
+from pysqlscribe.table import Table
+
+employee_table = Table("employee", "department", dialect="postgres")
+query = employee_table.select("department", distinct=True).build()
+```
+
+Output:
+
+```postgresql
+SELECT DISTINCT "department" FROM "employee"
+```
+
 ## NULL Checks
 Columns support `is_null()` and `is_not_null()` for NULL comparisons:
 

--- a/pysqlscribe/query.py
+++ b/pysqlscribe/query.py
@@ -36,9 +36,9 @@ class Query(AliasMixin):
     def dialect(self) -> Dialect:
         return self._dialect
 
-    def select(self, *args) -> Self:
+    def select(self, *args, distinct: bool = False) -> Self:
         if not self.node:
-            self.node = SelectNode({"columns": list(args)})
+            self.node = SelectNode({"columns": list(args), "distinct": distinct})
         return self
 
     def from_(self, *args) -> Self:

--- a/pysqlscribe/renderers/base.py
+++ b/pysqlscribe/renderers/base.py
@@ -22,6 +22,7 @@ from pysqlscribe.protocols import DialectProtocol
 from pysqlscribe.regex_patterns import WILDCARD_REGEX
 
 SELECT = "SELECT"
+DISTINCT = "DISTINCT"
 FROM = "FROM"
 WHERE = "WHERE"
 LIMIT = "LIMIT"
@@ -76,7 +77,8 @@ class Renderer:
 
     def render_select(self, node: SelectNode, collector: ParamCollector | None) -> str:
         columns = self._resolve_columns(*node.state["columns"], collector=collector)
-        return f"{SELECT} {columns}"
+        prefix = f"{DISTINCT} " if node.state.get("distinct") else ""
+        return f"{SELECT} {prefix}{columns}"
 
     def render_from(self, node: FromNode, collector: ParamCollector | None) -> str:
         tables = self.dialect.normalize_identifiers_args(

--- a/pysqlscribe/table.py
+++ b/pysqlscribe/table.py
@@ -19,8 +19,8 @@ class Table(Query, AliasMixin):
         self.schema = schema
         self.columns = columns
 
-    def select(self, *columns) -> Self:
-        return super().select(*columns).from_(self)
+    def select(self, *columns, distinct: bool = False) -> Self:
+        return super().select(*columns, distinct=distinct).from_(self)
 
     def order_by(self, *columns) -> Self:
         return super().order_by(*columns)

--- a/tests/test_distinct.py
+++ b/tests/test_distinct.py
@@ -1,0 +1,89 @@
+import pytest
+
+from pysqlscribe.query import Query
+from pysqlscribe.table import Table
+
+
+@pytest.mark.parametrize(
+    "dialect,expected",
+    [
+        ("postgres", 'SELECT DISTINCT "test_column" FROM "test_table"'),
+        ("mysql", "SELECT DISTINCT `test_column` FROM `test_table`"),
+        ("sqlite", 'SELECT DISTINCT "test_column" FROM "test_table"'),
+        ("oracle", 'SELECT DISTINCT "test_column" FROM "test_table"'),
+    ],
+)
+def test_select_distinct_per_dialect(dialect, expected):
+    query = (
+        Query(dialect).select("test_column", distinct=True).from_("test_table").build()
+    )
+    assert query == expected
+
+
+def test_select_distinct_multiple_columns():
+    query = (
+        Query("postgres")
+        .select("first_name", "last_name", distinct=True)
+        .from_("employees")
+        .build()
+    )
+    assert query == 'SELECT DISTINCT "first_name", "last_name" FROM "employees"'
+
+
+def test_select_distinct_default_false_emits_plain_select():
+    query = Query("postgres").select("test_column").from_("test_table").build()
+    assert query == 'SELECT "test_column" FROM "test_table"'
+
+
+def test_select_distinct_explicit_false_emits_plain_select():
+    query = (
+        Query("postgres")
+        .select("test_column", distinct=False)
+        .from_("test_table")
+        .build()
+    )
+    assert query == 'SELECT "test_column" FROM "test_table"'
+
+
+def test_select_distinct_with_where():
+    query = (
+        Query("postgres")
+        .select("department", distinct=True)
+        .from_("employees")
+        .where("salary > 1000")
+        .build()
+    )
+    assert query == 'SELECT DISTINCT "department" FROM "employees" WHERE salary > 1000'
+
+
+def test_select_distinct_with_parameterize():
+    table = Table("employees", "department", "salary", dialect="postgres")
+    sql, params = (
+        table.select("department", distinct=True)
+        .where(table.salary > 1000)
+        .build(parameterize=True)
+    )
+    assert sql == (
+        'SELECT DISTINCT "department" FROM "employees" WHERE employees.salary > %s'
+    )
+    assert params == [1000]
+
+
+def test_select_distinct_no_columns_emits_distinct_star():
+    # `select(distinct=True)` falls back to `*`. Standard SQL treats
+    # `SELECT DISTINCT *` as valid (and a no-op when the table has a key),
+    # so we just emit it rather than erroring.
+    query = Query("postgres").select(distinct=True).from_("test_table").build()
+    assert query == 'SELECT DISTINCT * FROM "test_table"'
+
+
+def test_table_select_distinct():
+    table = Table("employees", "department", dialect="mysql")
+    query = table.select("department", distinct=True).build()
+    assert query == "SELECT DISTINCT `department` FROM `employees`"
+
+
+def test_table_select_distinct_with_column_object():
+    table = Table("employees", "department", "salary", dialect="postgres")
+    query = table.select(table.department, distinct=True).build()
+    assert query == 'SELECT DISTINCT "department" FROM "employees"'


### PR DESCRIPTION
## Summary
- Adds a keyword-only `distinct=True` flag to `Query.select` / `Table.select` that emits `SELECT DISTINCT ...`. Default is unchanged.
- DISTINCT is a SELECT modifier, not a separate clause, so the kwarg lives on `SelectNode.state` rather than introducing a phantom node / `.distinct()` builder method.
- Works with all four dialects (postgres, mysql, sqlite, oracle), threads through to `parameterize=True` without affecting the params list, and composes with `WHERE` / `ORDER BY` / etc. as you'd expect.

## Example
```python
from pysqlscribe.table import Table

employees = Table("employees", "department", "salary", dialect="postgres")
employees.select("department", distinct=True).where(employees.salary > 1000).build()
# 'SELECT DISTINCT "department" FROM "employees" WHERE employees.salary > 1000'
```

## Decisions
- `select(distinct=True)` with no columns falls back to `*`, so it emits `SELECT DISTINCT *`. This is valid SQL (effectively a no-op when the table has a key) so we just pass it through rather than erroring. Documented in the test.
- DISTINCT inside aggregate functions (`COUNT(DISTINCT col)`) is intentionally out of scope for this PR.

## Test plan
- [x] `uv run pytest` — 241/241 passing (229 existing + 12 new in `tests/test_distinct.py`)
- [x] `uv run ruff check pysqlscribe tests` — clean
- [x] `uv run ruff format --check pysqlscribe tests` — clean
- [x] One unit test per dialect covering `SELECT DISTINCT` + escaping
- [x] Default `distinct=False` still emits plain SELECT
- [x] DISTINCT + WHERE
- [x] DISTINCT + `parameterize=True` (params list unaffected)
- [x] DISTINCT with no columns (documents the `SELECT DISTINCT *` behavior)
- [x] README updated with a `## DISTINCT` section

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>