### PR TITLE
Support date/datetime/Decimal/bool in inline build path

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ Params are appended in the order their placeholders appear in the rendered SQL, 
 ### Caveats
 
 - **Raw-string conditions are not parameterized.** When you pass a string directly to `where()` (e.g., `.where("salary > 1000")`), the literal stays inlined. Only typed comparisons through `Column` objects (e.g., `table.salary > 1000`) flow into the param list. A `bind()` opt-in helper for raw-string conditions is planned.
-- **Type support follows your driver, not the library.** The default (inline) build path supports `str`, `int`, `float`, and `None`. The parameterized path accepts any value your DB driver can bind — `datetime`, `date`, `Decimal`, `bool`, etc. all work without escaping logic on our side.
+- **Type support.** The inline build path supports `str`, `int`, `float`, `bool`, `None`, `datetime.date`, `datetime.datetime`, and `decimal.Decimal`. Booleans render as `TRUE` / `FALSE` for Postgres (ANSI standard) and as `1` / `0` for MySQL, SQLite, and Oracle, since those engines either lack a native boolean type or canonically store booleans as integers. The parameterized path additionally accepts anything else your DB driver can bind (e.g. `bytes`, `uuid.UUID`).
 - **`IS NULL` does not bind.** `col.is_null()` always renders as `IS NULL`, never as a placeholder, since drivers don't accept `NULL` via parameter binding for null-checks.
 
 ### Using a different driver / placeholder format

--- a/pysqlscribe/column.py
+++ b/pysqlscribe/column.py
@@ -1,3 +1,5 @@
+import datetime
+import decimal
 from typing import Self, Iterable, Protocol, runtime_checkable
 
 from pysqlscribe.alias import AliasMixin
@@ -20,10 +22,23 @@ class DialectLike(Protocol):
 def _ansi_escape_value(value) -> str:
     if isinstance(value, str):
         return "'" + value.replace("'", "''") + "'"
-    if isinstance(value, (int, float)):
+    # `bool` must be checked before `int` because `isinstance(True, int)` is True;
+    # ANSI SQL renders booleans as the keywords TRUE / FALSE.
+    if isinstance(value, bool):
+        return "TRUE" if value else "FALSE"
+    if isinstance(value, (int, float, decimal.Decimal)):
         return str(value)
+    # `datetime` must come before `date` because `datetime.datetime` subclasses
+    # `datetime.date`, so the order matters for the same MRO reason as bool/int.
+    if isinstance(value, datetime.datetime):
+        return "'" + value.isoformat(sep=" ") + "'"
+    if isinstance(value, datetime.date):
+        return "'" + value.isoformat() + "'"
     if value is None:
         return "NULL"
+    # TODO: bytes literals are dialect-specific (E'\\x...' for postgres,
+    # 0x... for mysql, X'...' for sqlite, HEXTORAW('...') for oracle); add when
+    # there's a real use-case to motivate the per-dialect rendering.
     raise NotImplementedError(
         f"Unsupported value type for SQL literal: {type(value).__name__}"
     )
@@ -200,7 +215,10 @@ class Column(AliasMixin):
                 other.fully_qualified_name,
                 dialect=self._dialect,
             )
-        if isinstance(other, (str, int, float)):
+        if isinstance(
+            other,
+            (str, int, float, bool, decimal.Decimal, datetime.date, datetime.datetime),
+        ):
             return Expression(
                 self.fully_qualified_name,
                 operator,

--- a/pysqlscribe/column.py
+++ b/pysqlscribe/column.py
@@ -5,7 +5,7 @@ from typing import Self, Iterable, Protocol, runtime_checkable
 from pysqlscribe.alias import AliasMixin
 from pysqlscribe.exceptions import InvalidColumnsError
 from pysqlscribe.functions import ScalarFunctions
-from pysqlscribe.params import Literal, ParamCollector
+from pysqlscribe.params import Literal, ParamCollector, ansi_escape_value
 from pysqlscribe.regex_patterns import (
     VALID_IDENTIFIER_REGEX,
     AGGREGATE_IDENTIFIER_REGEX,
@@ -19,31 +19,6 @@ class DialectLike(Protocol):
     def escape_value(self, value) -> str: ...
 
 
-def _ansi_escape_value(value) -> str:
-    if isinstance(value, str):
-        return "'" + value.replace("'", "''") + "'"
-    # `bool` must be checked before `int` because `isinstance(True, int)` is True;
-    # ANSI SQL renders booleans as the keywords TRUE / FALSE.
-    if isinstance(value, bool):
-        return "TRUE" if value else "FALSE"
-    if isinstance(value, (int, float, decimal.Decimal)):
-        return str(value)
-    # `datetime` must come before `date` because `datetime.datetime` subclasses
-    # `datetime.date`, so the order matters for the same MRO reason as bool/int.
-    if isinstance(value, datetime.datetime):
-        return "'" + value.isoformat(sep=" ") + "'"
-    if isinstance(value, datetime.date):
-        return "'" + value.isoformat() + "'"
-    if value is None:
-        return "NULL"
-    # TODO: bytes literals are dialect-specific (E'\\x...' for postgres,
-    # 0x... for mysql, X'...' for sqlite, HEXTORAW('...') for oracle); add when
-    # there's a real use-case to motivate the per-dialect rendering.
-    raise NotImplementedError(
-        f"Unsupported value type for SQL literal: {type(value).__name__}"
-    )
-
-
 def _resolve_value(value, dialect: DialectLike | None = None) -> str:
     """Render a CASE/comparison value: columns become fqn, pre-built expressions
     stringify as-is, and literals go through dialect escaping (ANSI fallback)."""
@@ -53,7 +28,7 @@ def _resolve_value(value, dialect: DialectLike | None = None) -> str:
         return str(value)
     if dialect is not None:
         return dialect.escape_value(value)
-    return _ansi_escape_value(value)
+    return ansi_escape_value(value)
 
 
 class _BetweenPair:

--- a/pysqlscribe/dialects/base.py
+++ b/pysqlscribe/dialects/base.py
@@ -1,5 +1,3 @@
-import datetime
-import decimal
 import os
 from abc import ABC, abstractmethod
 from typing import Dict
@@ -21,6 +19,7 @@ from pysqlscribe.ast.nodes import (
 )
 from pysqlscribe.env_utils import str2bool
 from pysqlscribe.exceptions import DialectValidationError
+from pysqlscribe.params import ansi_escape_value
 from pysqlscribe.regex_patterns import (
     VALID_IDENTIFIER_REGEX,
     AGGREGATE_IDENTIFIER_REGEX,
@@ -136,29 +135,11 @@ class Dialect(ABC):
     def escape_value(self, value) -> str:
         """Render a literal value as SQL, with dialect-appropriate escaping.
 
-        Default boolean rendering follows ANSI SQL (`TRUE` / `FALSE`); dialects
-        whose engines lack a native boolean type override this to emit `1` / `0`.
+        Default rendering follows ANSI SQL (booleans as ``TRUE``/``FALSE``,
+        ISO format for dates and datetimes); dialects whose engines lack a
+        native boolean type override this to emit ``1``/``0``.
         """
-        if isinstance(value, str):
-            return "'" + value.replace("'", "''") + "'"
-        # Order matters: `bool` is a subclass of `int`, and `datetime` is a
-        # subclass of `date`, so the more specific types must be checked first.
-        if isinstance(value, bool):
-            return "TRUE" if value else "FALSE"
-        if isinstance(value, (int, float, decimal.Decimal)):
-            return str(value)
-        if isinstance(value, datetime.datetime):
-            return "'" + value.isoformat(sep=" ") + "'"
-        if isinstance(value, datetime.date):
-            return "'" + value.isoformat() + "'"
-        if value is None:
-            return "NULL"
-        # TODO: dialect-specific bytes literals (E'\\x...' / 0x... / X'...' /
-        # HEXTORAW('...')) are out of scope; add when a real driver/use-case
-        # forces the choice.
-        raise NotImplementedError(
-            f"Unsupported value type for SQL literal: {type(value).__name__}"
-        )
+        return ansi_escape_value(value)
 
     def normalize_identifiers_args(self, *args, collector=None) -> str:
         arg = args[0]

--- a/pysqlscribe/dialects/base.py
+++ b/pysqlscribe/dialects/base.py
@@ -1,3 +1,5 @@
+import datetime
+import decimal
 import os
 from abc import ABC, abstractmethod
 from typing import Dict
@@ -132,11 +134,28 @@ class Dialect(ABC):
     def _escape_identifier(self, identifier: str): ...
 
     def escape_value(self, value) -> str:
-        """Render a literal value as SQL, with dialect-appropriate escaping."""
+        """Render a literal value as SQL, with dialect-appropriate escaping.
+
+        Default boolean rendering follows ANSI SQL (`TRUE` / `FALSE`); dialects
+        whose engines lack a native boolean type override this to emit `1` / `0`.
+        """
         if isinstance(value, str):
             return "'" + value.replace("'", "''") + "'"
-        if isinstance(value, (int, float)):
+        # Order matters: `bool` is a subclass of `int`, and `datetime` is a
+        # subclass of `date`, so the more specific types must be checked first.
+        if isinstance(value, bool):
+            return "TRUE" if value else "FALSE"
+        if isinstance(value, (int, float, decimal.Decimal)):
             return str(value)
+        if isinstance(value, datetime.datetime):
+            return "'" + value.isoformat(sep=" ") + "'"
+        if isinstance(value, datetime.date):
+            return "'" + value.isoformat() + "'"
+        if value is None:
+            return "NULL"
+        # TODO: dialect-specific bytes literals (E'\\x...' / 0x... / X'...' /
+        # HEXTORAW('...')) are out of scope; add when a real driver/use-case
+        # forces the choice.
         raise NotImplementedError(
             f"Unsupported value type for SQL literal: {type(value).__name__}"
         )

--- a/pysqlscribe/dialects/mysql.py
+++ b/pysqlscribe/dialects/mysql.py
@@ -19,4 +19,9 @@ class MySQLDialect(Dialect):
         if isinstance(value, str):
             escaped = value.replace("\\", "\\\\").replace("'", "''")
             return f"'{escaped}'"
+        # MySQL accepts TRUE / FALSE as aliases for 1 / 0, but stores booleans
+        # as TINYINT(1); rendering 1 / 0 keeps the inline output canonical and
+        # avoids depending on the alias. (Must precede int dispatch upstream.)
+        if isinstance(value, bool):
+            return "1" if value else "0"
         return super().escape_value(value)

--- a/pysqlscribe/dialects/oracle.py
+++ b/pysqlscribe/dialects/oracle.py
@@ -27,3 +27,11 @@ class OracleDialect(Dialect):
 
     def _escape_identifier(self, identifier: str) -> str:
         return f'"{identifier}"'
+
+    def escape_value(self, value) -> str:
+        # Oracle had no native BOOLEAN SQL type (in DML / table columns) before
+        # 23c; the long-standing convention is to use NUMBER(1) with 1 / 0, so
+        # render booleans that way for the inline path.
+        if isinstance(value, bool):
+            return "1" if value else "0"
+        return super().escape_value(value)

--- a/pysqlscribe/dialects/sqlite.py
+++ b/pysqlscribe/dialects/sqlite.py
@@ -13,3 +13,11 @@ class SQLiteDialect(Dialect):
 
     def _escape_identifier(self, identifier: str) -> str:
         return f'"{identifier}"'
+
+    def escape_value(self, value) -> str:
+        # SQLite has no native boolean type and stores booleans as the integers
+        # 1 / 0, so render them that way for the inline path. (Must precede
+        # the int branch in the base class.)
+        if isinstance(value, bool):
+            return "1" if value else "0"
+        return super().escape_value(value)

--- a/pysqlscribe/params.py
+++ b/pysqlscribe/params.py
@@ -1,4 +1,37 @@
+import datetime
+import decimal
 from typing import Any
+
+
+def ansi_escape_value(value: Any) -> str:
+    """Render a Python value as an ANSI SQL literal.
+
+    Used as the default for ``Dialect.escape_value`` and as the no-dialect
+    fallback in column expression rendering. Dialects override per type as
+    needed (e.g. MySQL/SQLite/Oracle render bool as ``1``/``0``).
+
+    isinstance ordering matters: ``bool`` is a subclass of ``int``, and
+    ``datetime.datetime`` is a subclass of ``datetime.date``, so the more
+    specific types are checked first.
+    """
+    if isinstance(value, str):
+        return "'" + value.replace("'", "''") + "'"
+    if isinstance(value, bool):
+        return "TRUE" if value else "FALSE"
+    if isinstance(value, (int, float, decimal.Decimal)):
+        return str(value)
+    if isinstance(value, datetime.datetime):
+        return "'" + value.isoformat(sep=" ") + "'"
+    if isinstance(value, datetime.date):
+        return "'" + value.isoformat() + "'"
+    if value is None:
+        return "NULL"
+    # TODO: bytes literals are dialect-specific (E'\\x...' for postgres,
+    # 0x... for mysql, X'...' for sqlite, HEXTORAW('...') for oracle); add
+    # when a real use-case forces the per-dialect rendering.
+    raise NotImplementedError(
+        f"Unsupported value type for SQL literal: {type(value).__name__}"
+    )
 
 
 class Literal:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,6 +20,15 @@ def sqlite_conn():
         "INSERT INTO employees VALUES (?, ?, ?)",
         [(1, "Alice", 100), (2, "Bob", 200), (3, "Carol", 300)],
     )
+    cur.execute("CREATE TABLE events (id INTEGER, created_at TEXT)")
+    cur.executemany(
+        "INSERT INTO events VALUES (?, ?)",
+        [
+            (1, "2026-04-27 09:00:00"),
+            (2, "2026-04-28 14:30:00"),
+            (3, "2026-04-29 12:00:00"),
+        ],
+    )
     conn.commit()
     yield conn
     conn.close()

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -3,6 +3,8 @@ driver, assert the rows come back. Catches placeholder-format and binding
 regressions that pure-string assertions can't see.
 """
 
+import datetime
+
 import pytest
 
 from pysqlscribe.table import Table
@@ -16,6 +18,20 @@ def test_sqlite_inline_build_executes(sqlite_conn):
     sql = employees.select("name").where(employees.salary > 150).build()
     rows = sqlite_conn.execute(sql).fetchall()
     assert sorted(name for (name,) in rows) == ["Bob", "Carol"]
+
+
+def test_sqlite_inline_build_with_datetime_literal_executes(sqlite_conn):
+    """Round-trip a datetime literal through the inline build path: proves the
+    rendered `'YYYY-MM-DD HH:MM:SS'` string is something a real driver accepts.
+    """
+    events = Table("events", "id", "created_at", dialect="sqlite")
+    sql = (
+        events.select("id")
+        .where(events.created_at == datetime.datetime(2026, 4, 28, 14, 30, 0))
+        .build()
+    )
+    rows = sqlite_conn.execute(sql).fetchall()
+    assert [row_id for (row_id,) in rows] == [2]
 
 
 def test_postgres_inline_build_executes(postgres_conn):

--- a/tests/test_inline_literal_types.py
+++ b/tests/test_inline_literal_types.py
@@ -8,8 +8,9 @@ from decimal import Decimal
 
 import pytest
 
-from pysqlscribe.column import Column, _ansi_escape_value
+from pysqlscribe.column import Column
 from pysqlscribe.dialects.base import DialectRegistry
+from pysqlscribe.params import ansi_escape_value
 from pysqlscribe.table import Table
 
 
@@ -71,8 +72,8 @@ def test_postgres_bool_is_not_rendered_as_int():
 
 def test_ansi_fallback_bool_is_not_rendered_as_int():
     """Same MRO trap, exercised against the dialect-less ANSI fallback path."""
-    assert _ansi_escape_value(True) == "TRUE"
-    assert _ansi_escape_value(False) == "FALSE"
+    assert ansi_escape_value(True) == "TRUE"
+    assert ansi_escape_value(False) == "FALSE"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_inline_literal_types.py
+++ b/tests/test_inline_literal_types.py
@@ -1,0 +1,159 @@
+"""Coverage for the inline (non-parameterized) literal-rendering path across
+the four supported dialects. Booleans, dates, datetimes, and Decimals all
+need to round-trip without raising NotImplementedError.
+"""
+
+import datetime
+from decimal import Decimal
+
+import pytest
+
+from pysqlscribe.column import Column, _ansi_escape_value
+from pysqlscribe.dialects.base import DialectRegistry
+from pysqlscribe.table import Table
+
+
+ALL_DIALECTS = ["postgres", "mysql", "sqlite", "oracle"]
+
+
+# ---------------------------------------------------------------------------
+# bool rendering — the per-dialect choice. Postgres uses ANSI TRUE/FALSE;
+# the rest emit 1/0 because their engines lack a real boolean type.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "dialect_name,expected_true,expected_false",
+    [
+        ("postgres", "TRUE", "FALSE"),
+        ("mysql", "1", "0"),
+        ("sqlite", "1", "0"),
+        ("oracle", "1", "0"),
+    ],
+)
+def test_bool_literal_rendering_per_dialect(
+    dialect_name, expected_true, expected_false
+):
+    dialect = DialectRegistry.get_dialect(dialect_name)
+    assert dialect.escape_value(True) == expected_true
+    assert dialect.escape_value(False) == expected_false
+
+
+@pytest.mark.parametrize(
+    "dialect_name,expected_true",
+    [
+        ("postgres", "TRUE"),
+        ("mysql", "1"),
+        ("sqlite", "1"),
+        ("oracle", "1"),
+    ],
+)
+def test_bool_in_where_clause_per_dialect(dialect_name, expected_true):
+    table = Table("flags", "id", "is_active", dialect=dialect_name)
+    sql = table.select("id").where(table.is_active == True).build()  # noqa: E712
+    assert sql.endswith(f"= {expected_true}")
+
+
+def test_postgres_bool_is_not_rendered_as_int():
+    """Regression: isinstance(True, int) is True in Python, so the bool branch
+    in escape_value must come before the int branch — otherwise postgres would
+    emit `1` / `0` instead of `TRUE` / `FALSE`.
+    """
+    dialect = DialectRegistry.get_dialect("postgres")
+    rendered_true = dialect.escape_value(True)
+    rendered_false = dialect.escape_value(False)
+    assert rendered_true == "TRUE"
+    assert rendered_false == "FALSE"
+    # And confirm we didn't accidentally fall through to str(int(bool)).
+    assert rendered_true != "1"
+    assert rendered_false != "0"
+
+
+def test_ansi_fallback_bool_is_not_rendered_as_int():
+    """Same MRO trap, exercised against the dialect-less ANSI fallback path."""
+    assert _ansi_escape_value(True) == "TRUE"
+    assert _ansi_escape_value(False) == "FALSE"
+
+
+# ---------------------------------------------------------------------------
+# date / datetime — same ISO formatting across all dialects.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dialect_name", ALL_DIALECTS)
+def test_date_literal_rendering(dialect_name):
+    dialect = DialectRegistry.get_dialect(dialect_name)
+    assert dialect.escape_value(datetime.date(2026, 4, 28)) == "'2026-04-28'"
+
+
+@pytest.mark.parametrize("dialect_name", ALL_DIALECTS)
+def test_datetime_literal_rendering(dialect_name):
+    dialect = DialectRegistry.get_dialect(dialect_name)
+    rendered = dialect.escape_value(datetime.datetime(2026, 4, 28, 14, 30, 0))
+    assert rendered == "'2026-04-28 14:30:00'"
+
+
+@pytest.mark.parametrize("dialect_name", ALL_DIALECTS)
+def test_datetime_with_microseconds_preserved(dialect_name):
+    dialect = DialectRegistry.get_dialect(dialect_name)
+    rendered = dialect.escape_value(datetime.datetime(2026, 4, 28, 14, 30, 0, 123456))
+    assert rendered == "'2026-04-28 14:30:00.123456'"
+
+
+@pytest.mark.parametrize("dialect_name", ALL_DIALECTS)
+def test_date_in_where_clause(dialect_name):
+    table = Table("events", "id", "occurred_on", dialect=dialect_name)
+    sql = (
+        table.select("id")
+        .where(table.occurred_on == datetime.date(2026, 4, 28))
+        .build()
+    )
+    assert sql.endswith("= '2026-04-28'")
+
+
+@pytest.mark.parametrize("dialect_name", ALL_DIALECTS)
+def test_datetime_in_where_clause(dialect_name):
+    table = Table("events", "id", "created_at", dialect=dialect_name)
+    sql = (
+        table.select("id")
+        .where(table.created_at == datetime.datetime(2026, 4, 28, 14, 30, 0))
+        .build()
+    )
+    assert sql.endswith("= '2026-04-28 14:30:00'")
+
+
+# ---------------------------------------------------------------------------
+# Decimal — rendered like int / float, no quoting.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dialect_name", ALL_DIALECTS)
+def test_decimal_literal_rendering(dialect_name):
+    dialect = DialectRegistry.get_dialect(dialect_name)
+    assert dialect.escape_value(Decimal("3.14")) == "3.14"
+    assert dialect.escape_value(Decimal("0")) == "0"
+    assert dialect.escape_value(Decimal("-1.5")) == "-1.5"
+
+
+@pytest.mark.parametrize("dialect_name", ALL_DIALECTS)
+def test_decimal_in_where_clause(dialect_name):
+    table = Table("ledger", "id", "amount", dialect=dialect_name)
+    sql = table.select("id").where(table.amount > Decimal("3.14")).build()
+    assert sql.endswith("> 3.14")
+
+
+# ---------------------------------------------------------------------------
+# ANSI fallback path — exercised when no dialect is attached to the column.
+# ---------------------------------------------------------------------------
+
+
+def test_ansi_fallback_renders_all_new_types():
+    col = Column("col", "tbl")  # no dialect
+    assert str(col == True) == "tbl.col = TRUE"  # noqa: E712
+    assert str(col == False) == "tbl.col = FALSE"  # noqa: E712
+    assert str(col == datetime.date(2026, 4, 28)) == "tbl.col = '2026-04-28'"
+    assert (
+        str(col == datetime.datetime(2026, 4, 28, 14, 30, 0))
+        == "tbl.col = '2026-04-28 14:30:00'"
+    )
+    assert str(col == Decimal("3.14")) == "tbl.col = 3.14"


### PR DESCRIPTION
## Summary

The inline build path (`query.build()`, the default) raised `NotImplementedError` on `bool`, `datetime.date`, `datetime.datetime`, and `decimal.Decimal` even though the parameterized path (`build(parameterize=True)`) handled them fine via the DB driver. That asymmetry pushed users into the parameterized API just to filter on a date — surprising for a query builder whose default story is inline-by-default.

This PR closes the gap on the inline path:

- `bool` -> `TRUE` / `FALSE` for Postgres, `1` / `0` for MySQL / SQLite / Oracle
- `datetime.date` -> `'YYYY-MM-DD'`
- `datetime.datetime` -> `'YYYY-MM-DD HH:MM:SS[.ffffff]'` (ISO with space separator; Postgres accepts both `T` and space, the rest treat space as canonical)
- `decimal.Decimal` -> `str(value)` (no quoting, like int / float)
- `bytes` is deliberately deferred — every dialect has its own literal syntax (`E'\\x...'`, `0x...`, `X'...'`, `HEXTORAW('...')`), out of scope for this pass; tracked as a TODO comment in `_ansi_escape_value` / `Dialect.escape_value`.

## Per-dialect bool decision

| Dialect  | True   | False   | Why |
| -------- | ------ | ------- | --- |
| Postgres | `TRUE` | `FALSE` | Native BOOLEAN type, ANSI-standard keywords. |
| MySQL    | `1`    | `0`     | MySQL accepts `TRUE` / `FALSE` as aliases but stores booleans as `TINYINT(1)`; rendering `1` / `0` matches the on-disk representation and avoids depending on the alias. |
| SQLite   | `1`    | `0`     | SQLite has no boolean type; integer storage class is canonical. |
| Oracle   | `1`    | `0`     | Oracle had no SQL-level BOOLEAN before 23c; the long-standing convention is `NUMBER(1)` with `1` / `0`. |

## isinstance ordering trap

`isinstance(True, int)` is `True` and `isinstance(datetime.datetime(...), datetime.date)` is `True`. The new `escape_value` paths put the more specific types first; there's a regression test (`test_postgres_bool_is_not_rendered_as_int`) that explicitly fails if anyone reorders the branches and accidentally renders Postgres booleans as `1` / `0`.

## Example

```python
from datetime import datetime
from decimal import Decimal

from pysqlscribe.table import Table

events = Table("events", "id", "created_at", "amount", "is_active", dialect="postgres")
events.select("id").where(
    events.created_at == datetime(2026, 4, 28, 14, 30, 0)
).build()
# 'SELECT "id" FROM "events" WHERE events.created_at = \'2026-04-28 14:30:00\''

events.select("id").where(events.amount > Decimal("3.14")).build()
# 'SELECT "id" FROM "events" WHERE events.amount > 3.14'

events.select("id").where(events.is_active == True).build()
# 'SELECT "id" FROM "events" WHERE events.is_active = TRUE'
```

## Test plan

- [x] `tests/test_inline_literal_types.py` covers all four types across all four dialects, plus an explicit regression for the bool/int MRO trap on both the Postgres dialect and the ANSI fallback.
- [x] `tests/integration/test_smoke.py::test_sqlite_inline_build_with_datetime_literal_executes` round-trips a datetime literal through the inline build path against a real SQLite driver.
- [x] `uv run pytest` -> 268 passed, 9 deselected
- [x] `uv run ruff check pysqlscribe tests` -> clean
- [x] `uv run ruff format --check pysqlscribe tests` -> clean
- [ ] Postgres integration tests (CI): runs `pytest -m integration` against a live postgres if the env var is set.

README "Caveats" bullet rewritten to advertise the new types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)